### PR TITLE
Pull requests: link to Github's recommendations

### DIFF
--- a/pull-requests.md
+++ b/pull-requests.md
@@ -1,5 +1,7 @@
 # The art of the pull request
 
+It is worth reading [Github's pull request conventions](https://github.com/blog/1943-how-to-write-the-perfect-pull-request) as this seem to cover most of the basics.
+
 Pull requests are:
 
 ## Small and frequent


### PR DESCRIPTION
Github's recommendations for PRs seem pretty common-sense so I thought we could link to them and essentially accept them as the basis for our own.
