### PR TITLE
Thrift: initial advice

### DIFF
--- a/thrift.md
+++ b/thrift.md
@@ -1,0 +1,5 @@
+# Thrift
+
+Don't use commas in the structure definitions.
+
+Don't mark a field as *required* unless the format is not yet in production.

--- a/thrift.md
+++ b/thrift.md
@@ -2,4 +2,8 @@
 
 Don't use commas or semi-colons in the structure definitions.
 
+## Post-production changes
+
 Don't mark a field as *required* unless the format is not yet in production.
+
+Once a definition has gone into production, the ordering of the existing fields must not be changed.

--- a/thrift.md
+++ b/thrift.md
@@ -1,5 +1,5 @@
 # Thrift
 
-Don't use commas in the structure definitions.
+Don't use commas or semi-colons in the structure definitions.
 
 Don't mark a field as *required* unless the format is not yet in production.


### PR DESCRIPTION
Commas are optional in the Thrift definition and we have started omitting them in our definitions.

The optional versus required is personal opinion but looking at how difficult it is to backfill database fields I thought it would be good to get this in early.