### PR TITLE
add `@guardian` packages recommendation

### DIFF
--- a/client-side.md
+++ b/client-side.md
@@ -6,10 +6,11 @@ free to justify why not.
 
 ## `@guardian` packages
 ### Publishing
-- Publish packages in ES2020 JavaScript
+- Publish packages in ES2020 JavaScript (see `target` in [TypeScript's compiler options](https://www.typescriptlang.org/docs/handbook/compiler-options.html))
+- Do not ship or depend on polyfills
 - Prefer including TypeScript types (e.g. [declaration files](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html))
 ### Consuming
-- Make sure you include all `@guardian` packages in `node_modules` in your transpilation toolchain 
+- Make sure you including any `@guardian` packages for transpilation in your build process 
   - e.g. in a [`webpack.config.js`](https://github.com/webpack/webpack/issues/2031#issuecomment-219040479)
 
 

--- a/client-side.md
+++ b/client-side.md
@@ -4,6 +4,15 @@ These are recommendations from the experiences of multiple teams
 across the Guardian. Feel free to not follow of them, but also feel
 free to justify why not.
 
+## `@guardian` packages
+### Publishing
+- Publish packages in ES2020 JavaScript
+- Prefer including TypeScript types (e.g. [declaration files](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html))
+### Consuming
+- Make sure you include all `@guardian` packages in `node_modules` in your transpilation toolchain 
+  - e.g. in a [`webpack.config.js`](https://github.com/webpack/webpack/issues/2031#issuecomment-219040479)
+
+
 ## Assets
 
 - Minify assets (e.g. uglify).


### PR DESCRIPTION
Here's the stuff @JamieB-gu and I put together for our `@guardian` npm packages recommendation – what do you think?

we had a further question:

- should we recommend publishing commonjs and esmodules, or just esm? @SiAdcock did you have to include cjs in source?

cc @guardian/client-side-infra  

_refs [this discussion](https://github.com/orgs/guardian/teams/client-side-infra/discussions/11) and https://github.com/guardian/dotcom-rendering/pull/1919_