### PR TITLE
Add section on third party dependencies

### DIFF
--- a/security.md
+++ b/security.md
@@ -53,6 +53,11 @@ preferentially used to permanent keys.
 
 **_All_ external endpoints should be served over HTTPS.**
 
+## Third party dependencies/software
+You should perform due diligence to check that any dependencies your 
+project uses are still supported and receive security updates. The 
+[snyk advisor](https://snyk.io/advisor/) is a helpful starting point.
+
 ## Personal hygiene
 
 **Disk encryption.** All machines that you do work on must have disk

--- a/security.md
+++ b/security.md
@@ -2,8 +2,7 @@
 
 ## Vulnerability management
 
-You should [perform due diligence](https://github.com/guardian/security-hq/blob/main/hq/markdown/vulnerability-management.md) to check that any dependencies your 
-project uses are still supported and receive security updates.
+You should [perform due diligence](https://github.com/guardian/security-hq/blob/main/hq/markdown/vulnerability-management.md) to check that any dependencies your project uses are still supported and receive security updates.
 
 ## Sensitive data
 

--- a/security.md
+++ b/security.md
@@ -1,5 +1,9 @@
 # Security
 
+## Vulnerability management
+
+Please ensure you [actively manage vulnerabilities from third party](https://github.com/guardian/security-hq/blob/main/hq/markdown/vulnerability-management.md).
+
 ## Sensitive data
 
 **Before building an application think about what (if any) sensitive

--- a/security.md
+++ b/security.md
@@ -2,7 +2,8 @@
 
 ## Vulnerability management
 
-Please ensure you [actively manage vulnerabilities from third party](https://github.com/guardian/security-hq/blob/main/hq/markdown/vulnerability-management.md).
+You should [perform due diligence](https://github.com/guardian/security-hq/blob/main/hq/markdown/vulnerability-management.md) to check that any dependencies your 
+project uses are still supported and receive security updates.
 
 ## Sensitive data
 
@@ -56,11 +57,6 @@ preferentially used to permanent keys.
 ## HTTPS everywhere
 
 **_All_ external endpoints should be served over HTTPS.**
-
-## Third party dependencies/software
-You should perform due diligence to check that any dependencies your 
-project uses are still supported and receive security updates. The 
-[snyk advisor](https://snyk.io/advisor/) is a helpful starting point.
 
 ## Personal hygiene
 


### PR DESCRIPTION
Adds  a few lines on third party dependencies, mainly highlighting the Snyk Advisor as a place to check if they're still maintained