### PR TITLE
chore: Add NPM CI recommendations

### DIFF
--- a/npm-packages.md
+++ b/npm-packages.md
@@ -165,3 +165,29 @@ module: {
 	]
 }
 ```
+
+## Running NPM packages as binaries in CI
+Various Node libraries can be run over the CLI using tools like `npx` or `yarn dlx`.
+
+The `npx` and `yarn dlx` tools are not deterministic as they do not work off a lockfile, they will install dependencies 
+according to the library's `package.json`.
+That is if the library depends on `^1.0.0` of a library, `npx` can resolve this to `1.0.0` today and `1.99.0` tomorrow.
+
+To ensure a deterministic and repeatable CI build, it is recommended to directly install a package and use a script to run it.
+This will result in entries in your project's lockfile as the library is treated like any other dependency.
+
+### Example
+Rather than `npx @guardian/node-riffraff-artifact`, prefer to update `package.json`:
+
+```
+{
+  "devDependencies": {
+    "@guardian/node-riffraff-artifact": "^0.2.1"
+  },
+  "scripts": {
+    "riffraff-upload": "node-riffraff-artifact"
+  }
+}
+```
+
+Then run script `npm run riffraff-upload` in CI.


### PR DESCRIPTION
Running `npx` or `yarn dlx` in CI is non-deterministic.

`npx` will install the latest version of dependencies that match the requirements in the library's `package.json`. This means if the library depends on version "^1.0.0" (any minor version on the 1 major) of a library, it could resolve to 1.0.0 today and 1.99.0 tomorrow.

Installing the dependency and running it via a script is preferred as we begin to treat the library like any other dependency. That is, the resulting lockfile can be used in CI to provide a deterministic and repeatable outcome.

## More detail
`@guardian/node-riffraff-artifact` was depending on `"aws-sdk": "^2.610.0"`.

The `tag-janitor` repository (among [others](https://github.com/search?q=org%3Aguardian+%22npx+%40guardian%2Fnode-riffraff-artifact%22&type=code)) is [running `npx @guardian/node-riffraff-artifact` in CI](https://github.com/guardian/tag-janitor/blob/66b1e8c839a199c4572186f807d58e2c62037a63/scripts/ci.sh#L32) and we've recently started to see CI on new PRs fail with:

```
Error: Cannot find module '/root/.npm/_npx/248/lib/node_modules/@guardian/node-riffraff-artifact/node_modules/aws-sdk/scripts/check-node-version.js'
```

The `@guardian/node-riffraff-artifact` library hasn't changed since the last successful build of `tag-janitor`, so what's causing the build to fail?

As it turns out, we can trace this specific error to a change released in [v2.894.0](https://github.com/aws/aws-sdk-js/pull/3727). The exact issue with this change is yet to be understood. 

However we can see that `npx` has progressed past installing `2.610.0` that `@guardian/node-riffraff-artifact` defined in it's `package.json` and thus we can confidently state that running `npx` is non-deterministic and should be avoided in CI.

It's worth noting that we've solved this specific issue with a plaster by [pinning the version of `aws-sdk`](https://github.com/guardian/node-riffraff-artifact/pull/25) used by `@guardian/node-riffraff-artifact`.