### PR TITLE
refactor: use better markdown techniques for CI and CD recommendations

### DIFF
--- a/continuous-deployment.md
+++ b/continuous-deployment.md
@@ -1,5 +1,8 @@
+[continuous integration]: continuous-integration.md
+[RiffRaff]: https://github.com/guardian/riff-raff
+
 Continuous Deployment
------
+=====================
 
 Continuous Deployment (CD) is a software release process where verified changes to a codebase are deployed immediately and autonomously to a production environment.
 
@@ -8,13 +11,13 @@ You should have continuous deployment set up for your repository, with the follo
 * Using an AMIgo AMI and regularly redeploying the application on a schedule
 * Restricting deployments if and when required
 
-You should already have [continuous integration](continuous-integration.md) configured in order to set up continuous deployment.
+You should already have [continuous integration] configured in order to set up continuous deployment.
 This ensures the deployed code is safe and ready for deployment. 
 
 ## Platforms
 
-* Use [RiffRaff](https://github.com/guardian/riffraff) to deploy your application, set up scheduled deploys and configure continuous deployment
+* Use [RiffRaff] to deploy your application, set up scheduled deploys and configure continuous deployment
     - Set up scheduled deploys, continuous deployment and deployment restrictions in the RiffRaff UI
     - Configure your RiffRaff deployment types inside your repository's `riff-raff.yaml` file 
 
-**See [continuous integration](continuous-integration.md)**
+**See [continuous integration]**

--- a/continuous-integration.md
+++ b/continuous-integration.md
@@ -1,5 +1,11 @@
+[Scripts To Rule Them All pattern]: https://github.com/github/scripts-to-rule-them-all
+[GitHub Actions]: https://docs.github.com/en/actions
+[RiffRaff]: https://github.com/guardian/riff-raff
+[`node-riffraff-artifact`]: https://www.npmjs.com/package/@guardian/node-riffraff-artifact
+[`sbt-riffraff-artifact`]: https://github.com/guardian/sbt-riffraff-artifact
+
 Continuous Integration
-====
+======================
 
 Continuous Integration (CI) is a practice where developers frequently push their code into a shared repository. 
 Automated builds and checks run on each check-in, allowing teams to detect problems early.
@@ -17,15 +23,15 @@ You should have continuous integration set up in your repository running the fol
 
 * Use TeamCity to run continuous integration tasks
 * Where possible, have CI execute a single, centralised script in the repository named `script/ci` 
-    - This adheres to GitHub's [Scripts To Rule Them All pattern](https://github.com/github/scripts-to-rule-them-all)
-* You can use [GitHub Actions](https://docs.github.com/en/actions) for most above tasks, however there is not currently a departmental best practice for uploading artifacts to RiffRaff through it.
+    - This adheres to GitHub's [Scripts To Rule Them All pattern]
+* You can use [GitHub Actions] for most above tasks, however there is not currently a departmental best practice for uploading artifacts to RiffRaff through it.
 
 ## Publishing artifacts
 
-You should publish artifacts to [RiffRaff](https://github.com/guardian/riff-raff). 
+You should publish artifacts to [RiffRaff]. 
 Two useful libraries for doing so are:
  
-* [`node-riffraff-artifact`](https://www.npmjs.com/package/@guardian/node-riffraff-artifact) for publishing Node project artifacts (such as AWS Lambdas)
-* [`sbt-riffraff-artifact`](https://github.com/guardian/sbt-riffraff-artifact) for publishing artifacts from Scala projects
+* [`node-riffraff-artifact`] for publishing Node project artifacts (such as AWS Lambdas)
+* [`sbt-riffraff-artifact`] for publishing artifacts from Scala projects
 
 **See [continuous deployment](continuous-deployment.md)**


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This implements @mxdvl 's recommendations on markdown improvements in #48 .
