### PR TITLE
Improve continuous integration

### DIFF
--- a/continuous-integration.md
+++ b/continuous-integration.md
@@ -25,7 +25,7 @@ Quoting `Martin Folwer`:
 
 _For most projects, however, the XP guideline of a ten minute build is perfectly within reason. Most of our modern projects achieve this. It's worth putting in concentrated effort to make it happen, because every minute you reduce off the build time is a minute saved for each developer every time they commit. Since CI demands frequent commits, this adds up to a lot of time._
 
-In a news organisation having a minimal time to revovery can be important due to the unpredictability of the news agenda, and the importance of timing.
+In a news organisation having a minimal time to recovery can be important due to the unpredictability of the news agenda, and the importance of timing.
 Every minute you reduce your building time is a minute saved when you will need to fix an issue on `PROD` at a critical moment. 
 
 

--- a/continuous-integration.md
+++ b/continuous-integration.md
@@ -23,7 +23,7 @@ You should have continuous integration set up in your repository running the fol
 The purpose of CI is to have rapid feedback and as such you should favour `speedness` over `correctness` and direct  `costs`.    
 Quoting `Martin Folwer`:  
 
-_For most projects, however, the XP guideline of a ten minute build is perfectly within reason. Most of our modern projects achieve this. It's worth putting in concentrated effort to make it happen, because every minute you reduce off the build time is a minute saved for each developer every time they commit. Since CI demands frequent commits, this adds up to a lot of time._
+> For most projects, however, the XP guideline of a ten minute build is perfectly within reason. Most of our modern projects achieve this. It's worth putting in concentrated effort to make it happen, because every minute you reduce off the build time is a minute saved for each developer every time they commit. Since CI demands frequent commits, this adds up to a lot of time.
 
 In a news organisation having a minimal time to recovery can be important due to the unpredictability of the news agenda, and the importance of timing.
 Every minute you reduce your building time is a minute saved when you will need to fix an issue on `PROD` at a critical moment. 

--- a/continuous-integration.md
+++ b/continuous-integration.md
@@ -7,17 +7,27 @@
 Continuous Integration
 ======================
 
-Continuous Integration (CI) is a practice where developers frequently push their code into a shared repository. 
-Automated builds and checks run on each check-in, allowing teams to detect problems early.
+[Continuous Integration (CI)](https://www.martinfowler.com/articles/continuousIntegration.html) is a practice where developers frequently integrate their work frequently, usually each person integrates at least daily, leading to multiple integrations per day. Each integration is verified by an automated build and checks run on each check-in, allowing teams to detect problems early.
 
 ## Tasks
 
 You should have continuous integration set up in your repository running the following tasks where relevant:
+* Linting your codebase
 * Running unit and integration tests
 * Building your application
-* Linting your codebase
 * Publishing artifacts
 * Other appropriate tasks for your repository
+
+## Keeping the process fast
+
+The purpose of CI is to have rapid feedback and as such you should favour `speedness` over `correctness` and direct  `costs`.    
+Quoting `Martin Folwer`:  
+
+_For most projects, however, the XP guideline of a ten minute build is perfectly within reason. Most of our modern projects achieve this. It's worth putting in concentrated effort to make it happen, because every minute you reduce off the build time is a minute saved for each developer every time they commit. Since CI demands frequent commits, this adds up to a lot of time._
+
+In a news organisation having a minimal time to revovery can be important due to the unpredictability of the news agenda, and the importance of timing.
+Every minute you reduce your building time is a minute saved when you will need to fix an issue on `PROD` at a critical moment. 
+
 
 ## Platforms
 

--- a/continuous-integration.md
+++ b/continuous-integration.md
@@ -7,7 +7,7 @@
 Continuous Integration
 ======================
 
-[Continuous Integration (CI)](https://www.martinfowler.com/articles/continuousIntegration.html) is a practice where developers frequently integrate their work frequently, usually each person integrates at least daily, leading to multiple integrations per day. Each integration is verified by an automated build and checks run on each check-in, allowing teams to detect problems early.
+[Continuous Integration (CI)](https://www.martinfowler.com/articles/continuousIntegration.html) is a practice where developers frequently integrate their work, usually each person integrates at least daily, leading to multiple integrations per day. Each integration is verified by an automated build and checks run on each check-in, allowing teams to detect problems early.
 
 ## Tasks
 


### PR DESCRIPTION
## What does this change?
- Slightly modify the definition of `CI` to be more precise and linked to martin fowler's article about it.
- Put `Linting` step as a first step, `before` the actual build step
- Emphasis importance of keeping the process fast  