### PR TITLE
chore: Update CI, adding GitHub Actions

### DIFF
--- a/continuous-integration.md
+++ b/continuous-integration.md
@@ -3,6 +3,7 @@
 [RiffRaff]: https://github.com/guardian/riff-raff
 [`node-riffraff-artifact`]: https://www.npmjs.com/package/@guardian/node-riffraff-artifact
 [`sbt-riffraff-artifact`]: https://github.com/guardian/sbt-riffraff-artifact
+[`guardian/actions-assume-aws-role`]: https://github.com/guardian/actions-assume-aws-role
 
 Continuous Integration
 ======================
@@ -31,10 +32,9 @@ Every minute you reduce your building time is a minute saved when you will need 
 
 ## Platforms
 
-* Use TeamCity to run continuous integration tasks
+* Use TeamCity or GitHub Actions (with [`guardian/actions-assume-aws-role`]) to run continuous integration tasks
 * Where possible, have CI execute a single, centralised script in the repository named `script/ci` 
     - This adheres to GitHub's [Scripts To Rule Them All pattern]
-* You can use [GitHub Actions] for most above tasks, however there is not currently a departmental best practice for uploading artifacts to RiffRaff through it.
 
 ## Publishing artifacts
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

With https://github.com/guardian/actions-assume-aws-role we're now able to use GitHub Actions as a CI platform.
That is, it is now possible to upload artifacts to Riff-Raff from within GitHub Actions.

Update the CI recommendations to reflect this.