### PR TITLE
Remove reference to deprecated GitHub Action

### DIFF
--- a/continuous-integration.md
+++ b/continuous-integration.md
@@ -3,7 +3,7 @@
 [RiffRaff]: https://github.com/guardian/riff-raff
 [`node-riffraff-artifact`]: https://www.npmjs.com/package/@guardian/node-riffraff-artifact
 [`sbt-riffraff-artifact`]: https://github.com/guardian/sbt-riffraff-artifact
-[`guardian/actions-assume-aws-role`]: https://github.com/guardian/actions-assume-aws-role
+[`aws-actions/configure-aws-credentials`]: https://github.com/aws-actions/configure-aws-credentials
 
 Continuous Integration
 ======================

--- a/continuous-integration.md
+++ b/continuous-integration.md
@@ -32,7 +32,7 @@ Every minute you reduce your building time is a minute saved when you will need 
 
 ## Platforms
 
-* Use TeamCity or GitHub Actions (with [`guardian/actions-assume-aws-role`]) to run continuous integration tasks
+* Use TeamCity or GitHub Actions (with [`aws-actions/configure-aws-credentials`]) to run continuous integration tasks
 * Where possible, have CI execute a single, centralised script in the repository named `script/ci` 
     - This adheres to GitHub's [Scripts To Rule Them All pattern]
 


### PR DESCRIPTION
## What does this change?

Updates our recommendations in response to the deprecation of https://github.com/guardian/actions-assume-aws-role.
