### PR TITLE
Add VPC section with link to Gateway Endpoints

### DIFF
--- a/AWS.md
+++ b/AWS.md
@@ -35,6 +35,11 @@ EC2
  * Use AMIs baked by Amigo.
  * Ensure that instances are kept up to date with new AMIs using Riff Raff scheduled deploys.
 
+
+VPC
+---
+* Ensure you have added the correct [Gateway Endpoints](https://docs.aws.amazon.com/vpc/latest/privatelink/vpce-gateway.html) for the AWS services being accessed from your private subnets to avoid incurring unnecessary networking costs.
+
 ELB
 ---
 


### PR DESCRIPTION
## What does this change?

Adds a recommendation to use gateway endpoints when talking to S3 & DynamoDB AWS services from a private subnet. 

When using private subnets you can unintentionally incur NAT Gateway costs by talking to AWS services over the internet if these endpoints are not in place and routing tables updated accordingly.