### PR TITLE
Update Alarming on 5XX Errors recommendation

### DIFF
--- a/AWS.md
+++ b/AWS.md
@@ -132,12 +132,14 @@ https://stackoverflow.com/questions/53898894/aws-lambda-timeout-when-another-lon
 Alarming on 5XX Errors (CloudWatch Metrics)
 ---
 When using EC2 and ELB/ALB there are two different counts for 5XX
-- `HTTPCode_Backend_5XX` produced by your application server
-- `HTTPCode_ELB_5XX` produced by the load balancer (metric name is slightly different for ALB) 
+- `HTTPCode_Backend_5XX` (ELB) / `HTTPCode_Target_5XX_Count` (ALB) produced by your application server
+- `HTTPCode_ELB_5XX` / `HTTPCode_ELB_5XX_Count` (ALB) produced by the load balancer
 
-To the client/consumer it doesn't matter what the source of the 5XX (backend or ELB).. it's still a 5XX - and we as engineers need to hear about it.
+To the client/consumer it doesn't matter what the source of the 5XX (application servers or load balancer).. it's still a 5XX - and we as engineers need to hear about it.
 
-Use 'Metric Math', to change any 5XX alarms to use the SUM of the `HTTPCode_Backend_5XX` and the `HTTPCode_ELB_5XX` metrics to capture ALL 5XX scenarios. For example see https://github.com/guardian/members-data-api/pull/425 
+If you are using `@guardian/cdk`, it is trivial to configure a 5XX alarm which combines these two metrics. For example see https://github.com/guardian/support-frontend/pull/3614.
+
+If you are still using CloudFormation, you will need to use 'Metric Math', to change any 5XX alarms to use the SUM of these metrics to capture ALL 5XX scenarios. For example see https://github.com/guardian/members-data-api/pull/425.
 
 ![image](5XX-department-email.png)
 

--- a/AWS.md
+++ b/AWS.md
@@ -133,9 +133,9 @@ Alarming on 5XX Errors (CloudWatch Metrics)
 ---
 When using EC2 and ELB/ALB there are two different counts for 5XX
 - `HTTPCode_Backend_5XX` (ELB) / `HTTPCode_Target_5XX_Count` (ALB) produced by your application server
-- `HTTPCode_ELB_5XX` / `HTTPCode_ELB_5XX_Count` (ALB) produced by the load balancer
+- `HTTPCode_ELB_5XX` (ELB) / `HTTPCode_ELB_5XX_Count` (ALB) produced by the load balancer
 
-To the client/consumer it doesn't matter what the source of the 5XX (application servers or load balancer).. it's still a 5XX - and we as engineers need to hear about it.
+To the client/consumer it doesn't matter what the source of the 5XX (application server or load balancer).. it's still a 5XX - and we as engineers need to hear about it.
 
 If you are using `@guardian/cdk`, it is trivial to configure a 5XX alarm which combines these two metrics. For example see https://github.com/guardian/support-frontend/pull/3614.
 


### PR DESCRIPTION
## What does this change?

A few small updates to @twrichards' advice for configuring an appropriate 5XX alarm:

1. Add the names of ALB metrics to make this advice easier to follow for newer applications
2. Remind engineers that `@guardian/cdk` will configure this alarm correctly for them and can save them from having to deal with metric math 😅 
