### PR TITLE
Add recommendation for logging in .json format to scala recommendations

### DIFF
--- a/npm-packages.md
+++ b/npm-packages.md
@@ -93,11 +93,17 @@ The CommonJS version should be referenced by the `main` field, and the TypeScrip
 
 #### Continuous delivery
 
-Use [Semantic Release](https://github.com/semantic-release/semantic-release) in a GitHub action.
+Prefer continuous delivery from GitHub, using either [Semantic Release](https://github.com/semantic-release/semantic-release) (see below) or [Changesets](https://github.com/changesets/changesets) in a GitHub action.
 
-If your release branch is protected ([a good idea](https://github.com/guardian/recommendations/blob/master/github.md)) use [guardian/actions-merge-release-changes-to-protected-branch](https://github.com/guardian/actions-merge-release-changes-to-protected-branch) to commit version bumps.
+Use the org secret `NPM_TOKEN` to publish to NPM. This will publish the package from our [`guardian-developers`](https://www.npmjs.com/~guardian-developers) NPM account.
 
-##### **Parsing Commit Messages**
+> This account is managed under npm@theguardian.com by the devex stream.
+
+##### Semantic Release
+
+If your release branch is protected ([a good idea](https://github.com/guardian/recommendations/blob/master/github.md)) use [guardian/actions-merge-release-changes-to-protected-branch](https://github.com/guardian/actions-merge-release-changes-to-protected-branch) to commit version bumps to `main`.
+
+###### **Parsing Commit Messages**
 
 Use tooling to help write and verify commits/PR titles. This will ensure that the [semantic-release/commit-analyser](https://github.com/semantic-release/commit-analyzer) plugin can determine the correct new version using one of the following strategies:
 
@@ -170,7 +176,7 @@ module: {
 ## Running NPM packages as binaries in CI
 Various Node libraries can be run over the CLI using tools like `npx` or `yarn dlx`.
 
-The `npx` and `yarn dlx` tools are not deterministic as they do not work off a lockfile, they will install dependencies 
+The `npx` and `yarn dlx` tools are not deterministic as they do not work off a lockfile, they will install dependencies
 according to the library's `package.json`.
 That is if the library depends on `^1.0.0` of a library, `npx` can resolve this to `1.0.0` today and `1.99.0` tomorrow.
 

--- a/scala.md
+++ b/scala.md
@@ -18,6 +18,39 @@ Most of the time, dependency injection does not solve a real business problem. Y
 
 With [The play framework](https://www.playframework.com/) you should always use [compile-time dependency injection](https://www.playframework.com/documentation/2.5.x/ScalaCompileTimeDependencyInjection) which refers to an object oriented way to specify your components declaratively in scala.
 
+If using Play 2.8 and wish to use net.logstash.logback.encoder.LogstashEncoder to output your logs in Java format, you will need to override the version of Jackson used to a later version.
+The reason for this is a deeply nested vulnerability in Jackson Databind version 2.11 which Jackson has patched for later versions but not 2.11 (See CVE-2020-36518 - GitHub Advisory Database).
+Unfortunately Play 2.8 uses Jackson Databind 2.11 and other Jackson libraries of this version.
+Play have said they don't plan to upgrade the Jackson version in Play 2.8 as they are scared of it breaking existing Play applications.
+Instead they have recommended adding code to your build sbt to override the Jackson dependencies to a later version:
+
+```
+val jacksonVersion         = "2.13.2"   // or 2.12.6
+val jacksonDatabindVersion = "2.13.2.2" // or 2.12.6.1
+
+val jacksonOverrides = Seq(
+  "com.fasterxml.jackson.core"     % "jackson-core",
+  "com.fasterxml.jackson.core"     % "jackson-annotations",
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8",
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310"
+).map(_ % jacksonVersion)
+
+val jacksonDatabindOverrides = Seq(
+  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
+)
+
+val akkaSerializationJacksonOverrides = Seq(
+  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor",
+  "com.fasterxml.jackson.module"     % "jackson-module-parameter-names",
+  "com.fasterxml.jackson.module"     %% "jackson-module-scala",
+).map(_ % jacksonVersion)
+
+libraryDependencies ++= jacksonDatabindOverrides ++ jacksonOverrides ++ akkaSerializationJacksonOverrides
+```
+
+See [this post](ttps://github.com/orgs/playframework/discussions/11222) for more information.
+Presumably this code can be stripped out when a new version of Play becomes available, so while it is ugly, it should only be temporary.
+
 
 
 


### PR DESCRIPTION
## What does this change?
When logging in .json format for a scala app, it is necessary to use net.logstash.logback.encoder.LogstashEncoder.
When using this with Play 8.x you are exposed to a Denial of Service vulnerability in the Jackson library used by this version of Play.
This change documents this problem and adds details for the current workaround to resolve this issue.

Trello card: https://trello.com/c/tiXyFoIv/1259-support-ingesting-json-logs-and-define-best-practice-on-this