### PR TITLE
Encourage devs to check their PRs after merging

### DIFF
--- a/pull-requests.md
+++ b/pull-requests.md
@@ -41,3 +41,23 @@ No-one loves someone who writes the same comment fifteen times on a pull request
 Don't try and hold a conversation in a pull request. If you have more than three comments or three paragraphs in a pull request then consider simply talking through the issues with the person who raised the pull request.
 
 Record the outcome and actions of the conversation on the pull request so everyone else can follow the review.
+
+## Merging is not the end!
+
+A PR is not finished when you merge it - check your PR in Production after it's deployed! Although unit & integration tests can add a lot of confidence that your change is good, looking at your change in Production is the ultimate and most important place to check your PR is delivering what's wanted.
+
+For webapps you can use [Prout](https://github.com/guardian/prout) to let you know when your change has reached Production and is ready to be looked at.
+
+A good way to get into the habit of doing post-merge checks is to write one final comment on your PR, detailing what you looked at:
+
+### Writing an informative post-merge PR comment
+
+A good post-merge comment on a PR can provide evidence that the PR works, or showcase the benefits of doing the PR in the first place! It can answer questions future developers may have, like "Did this stuff _ever_ work?" or "Did this help? Should I make a similar change in my repo?".
+
+Here are some examples of what you could put in a post-merge comment - if your PR was adding:
+
+* **Metrics or Logging** : Include a sample or screenshot of the newly gathered data, with a link to the ELK or dashboard to make it easy to get to that data in the future ([example](https://github.com/guardian/ophan/pull/4065#issuecomment-802200900))
+* **A new UI feature** : A screenshot or even video of the feature in action in Production. This doesn't need to be too extensive, because you should already have screenshots/video in the main PR description! If the new feature is being A/B tested, you may want to link to the results. ([example](https://github.com/guardian/ophan/pull/3406#issuecomment-522595859))
+* **Performance improvements** : A graph showing how performance has improved post-deployment! ([example](https://github.com/guardian/ophan/pull/4435#issuecomment-1056778719))
+* **A security/bug fix** : any evidence that the bug is no longer there, eg a screenshot, video, or log-search. ([example](https://github.com/guardian/ophan/pull/2896#issuecomment-415489771))
+


### PR DESCRIPTION
As a dev it's very easy, as soon as you merge a PR, to think of it as completed, and move on to the next thing. However, this is actually the most important time to check that the change is *working*!

This recommendation update aims to encourage devs to extend their mental model of the lifecycle of a PR a little further, post-merge, to take a little time to check on the change.
