### PR TITLE
Fix link to `jsxImportSource`

### DIFF
--- a/emotion.md
+++ b/emotion.md
@@ -17,7 +17,7 @@ $ yarn add @emotion/react
 Emotion can be configured for TypeScript or Babel, depending on your setup. If you are using both, you only need to do one (TypeScript is simplest).
 ### TypeScript
 
-If you are using TypeScript <= 4.1 and React <=17, it's simplest to use [React's automatic runtime](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) with TypeScript's attendant [jsx](https://www.typescriptlang.org/tsconfig#jsx) and [jsxImportSource}(https://www.typescriptlang.org/tsconfig#jsxImportSource) compiler options.
+If you are using TypeScript <= 4.1 and React <=17, it's simplest to use [React's automatic runtime](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) with TypeScript's attendant [jsx](https://www.typescriptlang.org/tsconfig#jsx) and [jsxImportSource](https://www.typescriptlang.org/tsconfig#jsxImportSource) compiler options.
 
 For earlier versions, use the Babel setup described below.
 


### PR DESCRIPTION
## What does this change?

- Fixes markdown for link to `jsxImportSource`
