### PR TITLE
Node.js recommendations for client side projects

### DIFF
--- a/client-side.md
+++ b/client-side.md
@@ -37,6 +37,7 @@ See the separate [npm-packages.md](./npm-packages.md).
 
 -   Prefer using the _Current_ even-numbered [version of Node.js](https://nodejs.org/en/about/releases/)
 -   Use an `.nvmrc` file to indicate the exact version of Node.js your project uses
+    - *Note:* `asdf` users must configure their tool to use [legacy version files](https://github.com/asdf-vm/asdf-nodejs#nvmrc-and-node-version-support)
 
 
 ## Strategies

--- a/client-side.md
+++ b/client-side.md
@@ -38,6 +38,7 @@ See the separate [npm-packages.md](./npm-packages.md).
 -   Prefer using the _Current_ even-numbered [version of Node.js](https://nodejs.org/en/about/releases/)
     - Odd-numbered versions become unsupported more quickly than even-numbered
 -   Use an `.nvmrc` file to indicate the exact version of Node.js your project uses
+	- It's the only node version file that is supported by all current node version management tools
     - `asdf` users must configure their tool to use [legacy version files](https://github.com/asdf-vm/asdf-nodejs#nvmrc-and-node-version-support)
 
 

--- a/client-side.md
+++ b/client-side.md
@@ -33,6 +33,12 @@ See the separate [npm-packages.md](./npm-packages.md).
     otherwise.
 -   Prefer locking your dependencies (direct and transitive) using a lockfile rather than committing them into Git.
 
+## Node.js
+
+-   Prefer using the _Current_ even-numbered [version of Node.js](https://nodejs.org/en/about/releases/)
+-   Use an `.nvmrc` file to indicate the exact version of Node.js your project uses
+
+
 ## Strategies
 
 Rather than enforcing strict rules that may differ across constraints

--- a/client-side.md
+++ b/client-side.md
@@ -36,8 +36,9 @@ See the separate [npm-packages.md](./npm-packages.md).
 ## Node.js
 
 -   Prefer using the _Current_ even-numbered [version of Node.js](https://nodejs.org/en/about/releases/)
+    - Odd-numbered versions become unsupported more quickly than even-numbered
 -   Use an `.nvmrc` file to indicate the exact version of Node.js your project uses
-    - *Note:* `asdf` users must configure their tool to use [legacy version files](https://github.com/asdf-vm/asdf-nodejs#nvmrc-and-node-version-support)
+    - `asdf` users must configure their tool to use [legacy version files](https://github.com/asdf-vm/asdf-nodejs#nvmrc-and-node-version-support)
 
 
 ## Strategies


### PR DESCRIPTION
## What does this change?

Specify recommendations for Node.js projects

To me, it always makes sense to use the latest even-numbered version of Node, unless there is a good reason not to. 

Odd-numbered versions become unsupported more quickly than even-numbered.

Although there are newer version managers than nvm, the `.nvmrc` file is still the most prevalent and well-supported file for indicating Node.js version. `fnm`, `asdf` and `nvm` all support `.nvmrc` files