### PR TITLE
Prefer systemd timers to crontab for scheduled jobs

### DIFF
--- a/scheduled-jobs.md
+++ b/scheduled-jobs.md
@@ -1,0 +1,23 @@
+# Scheduled jobs - tasks that run periodically
+
+## Cron expressions
+
+'cron' syntax (eg [`*/5 1,2,3 * * *`](https://crontab.guru/#*/5_1,2,3_*_*_*)) is a way of specifying times for jobs to run, popularised by [`crontab`](https://en.wikipedia.org/wiki/Cron#Overview), widely supported in other systems like `systemd`, [Amazon EventBridge Scheduler](https://docs.aws.amazon.com/scheduler/latest/UserGuide/schedule-types.html#cron-based), etc.
+
+Tools like https://crontab.guru/ are great to explore cron expressions, but note that [the fields used in cron syntax can vary](https://github.com/guardian/ophan-geoip-db-refresher/pull/3#discussion_r638614229), so check the documentation for the system you're working on.
+
+## Job scheduling in different environments
+
+### UNIX / EC2
+
+Prefer [systemd timers](https://askubuntu.com/a/1051208/17211) (configured in `/etc/systemd/system/foo.timer`) to `crontab` jobs (configured in eg `/etc/crontab`):
+
+* **Logging** : `systemd` provides better logging by default (e.g. `journalctl -u foo.timer` to see the logs). `crontab` may attempt to _email_ job output - this will fail as we typically don't have EC2 boxes configured to send email.
+* **Security** : It's easy to unintentionally run `crontab` jobs as `root` (with all-powerful superuser access). `systemd` encourages you to be explicit about which _user_ the task should run as - this should be a user with a restricted set of permissions, not root!
+* **Timezones** : Ubuntu `crontab` [uses the server timezone](https://github.com/guardian/deploy-tools-platform/pull/533) to schedule jobs, while systemd allows custom timezone scheduling (e.g. you can schedule a job to start before office-hours, etc).
+
+See also https://opensource.com/article/20/7/systemd-timers.
+
+### AWS Lambda
+
+An [`AWS::Events::Rule`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html) can invoke an AWS Lambda at regular intervals.


### PR DESCRIPTION
Suggesting a new recommendation here - while debugging the issues behind https://github.com/guardian/grid-ftp/pull/13, @sihil pointed out that systemd timers have advantages over crontab jobs! They do require a bit more setup (eg separate `.service` & `.timer` files), but it sounds like we should probably prefer them, and let people know about them?

At the moment, GitHub search seems to show only a few places where we use [systemd-timers](https://github.com/search?q=org%3Aguardian+systemd+timer&type=code), whereas there are _lots_ of [`crontab`](https://github.com/search?p=2&q=org%3Aguardian+crontab&type=Code).
