### PR TITLE
feat(dependencies): list TS as non-SemVer

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -48,9 +48,9 @@ This is especially important for [published packages](./npm-packages.md).
 There are a few examples of packages which **do not** follow SemVer, and for
 which a specific version should be specified:
 
-- [`aws-cdk`][]: minor and patch versions can introduce breaking changes
+- [`aws-cdk`](https://www.npmjs.com/package/aws-cdk): minor and patch versions can introduce breaking changes
+- [`typescript`](https://www.npmjs.com/package/aws-cdk): major and minor versions can introduce breaking changes
 
-[`aws-cdk`]: https://www.npmjs.com/package/aws-cdk
 ## Peer and Development dependencies
 
 ### `devDependencies`


### PR DESCRIPTION
## What is being recommended?

Add TypeScript to the list of non-semver packages.

This is [“by design”](https://github.com/microsoft/TypeScript/wiki/Breaking-Changes) for this project.

## What's the context?

- https://github.com/guardian/csnx/issues/461
- https://chat.google.com/room/AAAAWwBdSMs/b_xVhap5IYY
- https://docs.google.com/document/d/1Vi7m35w46F72z6n4fucsxm6i28xbmn2iMfPGM7zWGz8/edit#heading=h.vtwbgvn0qym8