### PR TITLE
Remove deprecated/EOL CI references

### DIFF
--- a/applications.md
+++ b/applications.md
@@ -4,5 +4,5 @@ Applications
  * applications should be responsible for a single purpose. This implies:
    * dependent on at most one external service responding in order to respond to a request
    * scale based on one metric, e.g. queue length, response time
- * applications should be deployed based on an artifact built by teamcity
+ * applications should be deployed based on an artifact built by GitHub Actions
  * applications should be deployed by RiffRaff

--- a/continuous-integration.md
+++ b/continuous-integration.md
@@ -1,8 +1,7 @@
 [Scripts To Rule Them All pattern]: https://github.com/github/scripts-to-rule-them-all
 [GitHub Actions]: https://docs.github.com/en/actions
 [RiffRaff]: https://github.com/guardian/riff-raff
-[`node-riffraff-artifact`]: https://www.npmjs.com/package/@guardian/node-riffraff-artifact
-[`sbt-riffraff-artifact`]: https://github.com/guardian/sbt-riffraff-artifact
+[`actions-riff-raff`]:https://github.com/guardian/actions-riff-raff/
 [`aws-actions/configure-aws-credentials`]: https://github.com/aws-actions/configure-aws-credentials
 
 Continuous Integration
@@ -32,16 +31,13 @@ Every minute you reduce your building time is a minute saved when you will need 
 
 ## Platforms
 
-* Use TeamCity or GitHub Actions (with [`aws-actions/configure-aws-credentials`]) to run continuous integration tasks
+* Use GitHub Actions (with [`aws-actions/configure-aws-credentials`]) to run continuous integration tasks
 * Where possible, have CI execute a single, centralised script in the repository named `script/ci` 
     - This adheres to GitHub's [Scripts To Rule Them All pattern]
 
 ## Publishing artifacts
 
 You should publish artifacts to [RiffRaff]. 
-Two useful libraries for doing so are:
- 
-* [`node-riffraff-artifact`] for publishing Node project artifacts (such as AWS Lambdas)
-* [`sbt-riffraff-artifact`] for publishing artifacts from Scala projects
+A useful action for doing so is [`actions-riff-raff`]
 
 **See [continuous deployment](continuous-deployment.md)**

--- a/ownership.md
+++ b/ownership.md
@@ -12,7 +12,7 @@ N.B. This guidance only intended as a minimum baseline; in practice the expectat
 - All source code should be version controlled using [GitHub](./github.md)
 - CI/CD should be employed
     - An appropriate testing strategy should be considered. We do not aim for a specific % of test coverage, but important business logic should be unit tested
-    - For CI, we use GitHub Actions and [Teamcity](https://teamcity.gutools.co.uk/)
+    - For CI, use GitHub Actions
     - For most (non-library) projects, deployment will be done via [Riff-Raff](https://riffraff.gutools.co.uk/)
 
 ### Security


### PR DESCRIPTION
## What is being recommended?

Removing recommendations to use TeamCity, 
[sbt-riffraff-artifact](https://github.com/guardian/sbt-riffraff-artifact) and
[node-riffraff-artifact](https://www.npmjs.com/package/@guardian/node-riffraff-artifact)

## What's the context?

We are encouraging teams to move to github actions ahead of the teamcity deprecation, so this should no longer be a recommendation

> **Note**
> 
> The recommendations in this repository are intended to share engineering best practices for all of Product & Engineering (P&E) in the open. 
> 
> Some considerations:
>  - Should this really be an ADR in another repository?
>  - Have you sought review widely enough (Developer Experience, Heads of Engineering)? 
>  - If it is security related, should you consult with Information Security?
