### PR TITLE
Clarify JS, NPM & Dependencies recommendations

### DIFF
--- a/client-side.md
+++ b/client-side.md
@@ -22,16 +22,17 @@ See the separate [npm-packages.md](./npm-packages.md).
 
 -   Have an [.editorconfig](http://editorconfig.org/) file in your repo.
 -   Automate linting as part of your test phase (e.g. jshint, eslint,
-    csslint).
-    -   Use the [departmental linting rules](https://github.com/guardian/configs)
+    csslint) using the department linting rules:
+    - [@guardian/eslint-config](https://github.com/guardian/csnx/tree/main/libs/%40guardian/eslint-config)
+    - [@guardian/eslint-config-typescript](https://github.com/guardian/csnx/tree/main/libs/%40guardian/eslint-config-typescript)
+    - [@guardian/tsconfig](https://github.com/guardian/csnx/tree/main/libs/%40guardian/tsconfig)
+    - [@guardian/prettier](https://github.com/guardian/csnx/tree/main/libs/%40guardian/prettier)
 -   Don’t enforce coding styles in pull requests. Add linting dot files
     (e.g. .jshintrc) to your project instead.
 
 ## Dependencies
 
--   If starting a new project, favour ES6 modules unless you can justify
-    otherwise.
--   Prefer locking your dependencies (direct and transitive) using a lockfile rather than committing them into Git.
+See the separate [dependencies.md](./dependencies.md#javascript).
 
 ## Node.js
 

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,5 +1,4 @@
-Dependencies
-============
+# Dependencies
 
 The software we develop often depends on standalone packaged libraries.
 Managing these dependencies is crucial to delivery: we need processes that yield
@@ -28,7 +27,7 @@ Dependencies should be pinned to the `minor` version.
 
 See the [Scala-specific recommendations](./scala.md)
 
-## JavaScript: NPM Dependencies
+## JavaScript
 
 Dependencies in JavaScript can be either imported directly from a URL,
 or managed with Node and a build system based on `package.json` declaration.
@@ -41,33 +40,4 @@ acceptable ranges using the _caret_ or _tilde_ notation.
 - A leading caret `^1.0.0` accepts any subsequent minor or patch version.
 - A leading tilde `~1.1.0` accepts any subsequent patch version.
 
-This is especially important for [published packages](./npm-packages.md).
-
-### Known non-semver packages
-
-There are a few examples of packages which **do not** follow SemVer, and for
-which a specific version should be specified:
-
-- [`aws-cdk`](https://www.npmjs.com/package/aws-cdk): minor and patch versions can introduce breaking changes
-- [`typescript`](https://www.npmjs.com/package/aws-cdk): major and minor versions can introduce breaking changes
-
-## Peer and Development dependencies
-
-### `devDependencies`
-
-Development dependencies can be pinned to a specific version, as they are not
-bundled in the final client bundle.
-
-### `peerDependencies`
-
-Assuming the package you depend on follows SemVer, prefer using the caret (`^`)
-style for `peerDependencies` and specify the lowest acceptable minor version. If
-any minor version of a given major version is okay, then this can be as simple
-as `^3`, for example.
-
-Any `peerDependencies` you specify should be duplicated in `devDependencies` in
-order to be able to run tests locally or in CI.
-
-In some cases your package might work across multiple major versions of a peer
-dependency. In this case you can use the `||` notation. For example if your
-package works with TypeScript 3 or 4 you could write: `^3 || ^4`.
+When developing libraries to be published as NPM packages, [see specific recommendations](./npm-packages.md).

--- a/npm-packages.md
+++ b/npm-packages.md
@@ -66,8 +66,7 @@ This is only an example, there are many ways of configuring this.
 
 ### Configuring your package
 
-NPM packages are described in a `package.json` file.
-Dependencies should specify [allowed version ranges](./dependencies.md#JavaScript-NPM-Dependencies).
+NPM packages are described in a [`package.json` file](https://docs.npmjs.com/cli/v9/configuring-npm/package-json).
 
 #### NPM scope
 
@@ -131,6 +130,13 @@ If your library depends on other libraries, list them as `peerDependencies` in y
 #### `peerDependencies` ranges should be a wide as possible
 
 This ensures compatibility with the maximum number of installations.
+Read more about [NPM’s range syntax](https://docs.npmjs.com/cli/v6/using-npm/semver#advanced-range-syntax).
+
+Generally, this means using a leading caret which accepts any subsequent minor or patch version (e.g. `^1.0.1`).
+However, there are a few of packages which **do not** follow semantic versioning, and for which narrower ranges should be specified:
+
+- [`aws-cdk`](https://www.npmjs.com/package/aws-cdk): minor and patch versions can introduce breaking changes, use a pinned version
+- [`typescript`](https://www.npmjs.com/package/aws-cdk): major and minor versions can introduce breaking changes, use a leading tilde (e.g. `~4.9.5`)
 
 ##### Example
 

--- a/npm-packages.md
+++ b/npm-packages.md
@@ -76,7 +76,7 @@ Publish under the [`@guardian`](https://www.npmjs.com/org/guardian) scope.
 
 Imagine you're working on a re-usable slideshow widget for Guardian web pages:
 
-```js
+```jsonc
 // package.json
 {
 	"name": "@guardian/slideshow",
@@ -94,7 +94,7 @@ The CommonJS version should be referenced by the `main` field.
 
 ##### Example
 
-```js
+```jsonc
 // package.json
 {
 	"main": "dist/cjs/index.js", // dist/cjs/index.d.ts is included
@@ -105,7 +105,7 @@ The CommonJS version should be referenced by the `main` field.
 
 or
 
-```js
+```jsonc
 // package.json
 {
 	"main": "dist/cjs/index.js",
@@ -142,7 +142,7 @@ However, there are a few of packages which **do not** follow semantic versioning
 
 Imagine `@guardian/slideshow` uses `_.zipObjectDeep`, which was [added to Lodash in v4.1.0](https://github.com/lodash/lodash/wiki/Changelog#v410):
 
-```js
+```jsonc
 // package.json
 {
 	"name": "@guardian/slideshow",
@@ -161,7 +161,7 @@ This prevents you accidentally developing against a feature of a dependency that
 
 ##### Example
 
-```js
+```jsonc
 // package.json
 {
 	"name": "@guardian/slideshow",
@@ -187,7 +187,7 @@ This is because it will require the consumer to make changes to their project, s
 
 Here's an application that consumes `@guardian/slideshow`:
 
-```js
+```jsonc
 // package.json
 {
 	"name": "new-website",
@@ -200,7 +200,7 @@ Here's an application that consumes `@guardian/slideshow`:
 
 Now imagine a new version `@guardian/slideshow` adds a feature that uses `_.update`, which was [added to Lodash in v4.6.0](https://github.com/lodash/lodash/wiki/Changelog#v460):
 
-```js
+```jsonc
 // package.json
 {
 	"name": "@guardian/slideshow",
@@ -216,7 +216,7 @@ Now imagine a new version `@guardian/slideshow` adds a feature that uses `_.upda
 
 I update my app to use the new version of `@guardian/slideshow`:
 
-```js
+```jsonc
 // package.json
 {
 	"name": "new-website",
@@ -243,7 +243,7 @@ This means they are always up-to-date with the latest versions of their deps.
 
 Imagine `new-website` and `@guardian/slideshow` both live in the same monorepo:
 
-```js
+```jsonc
 // package.json
 {
 	"name": "new-website",
@@ -258,7 +258,7 @@ It is tempting to do the same with `peerDependencies` of packages.
 
 Imagine `@guardian/slideshow` starts using something from `@guardian/libs`, which is also in the monorepo:
 
-```js
+```jsonc
 // package.json
 {
 	"name": "@guardian/libs",
@@ -266,7 +266,7 @@ Imagine `@guardian/slideshow` starts using something from `@guardian/libs`, whic
 }
 ```
 
-```js
+```jsonc
 // package.json
 {
 	"name": "@guardian/slideshow",
@@ -304,7 +304,7 @@ Imagine `@guardian/slideshow` uses `ArticleDesign.Gallery` from `@guardian/libs`
 
 Although `@guardian/libs` is at v6.5.2 in the repo and would work fine, we still won't use it directly:
 
-```js
+```jsonc
 // package.json
 {
 	"name": "@guardian/slideshow",
@@ -379,14 +379,14 @@ This will result in entries in your project's lockfile as the library is treated
 
 Rather than `npx @guardian/node-riffraff-artifact`, prefer to update `package.json`:
 
-```
+```json
 {
-  "devDependencies": {
-	"@guardian/node-riffraff-artifact": "^0.2.1"
-  },
-  "scripts": {
-	"riffraff-upload": "node-riffraff-artifact"
-  }
+	"devDependencies": {
+		"@guardian/node-riffraff-artifact": "^0.2.1"
+	},
+	"scripts": {
+		"riffraff-upload": "node-riffraff-artifact"
+	}
 }
 ```
 


### PR DESCRIPTION
## What is being recommended?

The `dependencies`, `npm-packages` and `client-side` recommendations have been reworked so they no longer contradict each other.

## What's the context?

Follow-up on #53 & #59.