### PR TITLE
Introduce a table of best practices

### DIFF
--- a/best-practices.md
+++ b/best-practices.md
@@ -1,0 +1,18 @@
+<!--
+Before adding a best practice, consider:
+  - How one can identify if it's being followed (e.g. a dashboard)
+  - How to exempt from it
+-->
+
+# Best Practices
+This document defines a list of best practices we have defined. 
+
+## GitHub
+| ID | Name | Owner         | Description                                                                                                                                     | How to check compliance                           | How to exempt |
+| -- | ---- |---------------|-------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------|---------------|
+| GH-01 | DefaultBranchName | [@guardian](https://github.com/orgs/guardian/teams/all) | The default branch name should be `main`.<br>See the [master-to-main tool](https://github.com/guardian/master-to-main/blob/main/migrating.md). | Manual. View the repository on https://github.com | N/A |
+
+## AWS
+| ID | Name | Owner         | Description                                                                                                                                     | How to check compliance                           | How to exempt |
+| -- | ---- |---------------|-------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------|---------------|
+| AWS-01 | Tagging | [DevX Operations](https://github.com/orgs/guardian/teams/devx-operations) | AWS resources should be tagged (where supported) with `Stack`, `Stage`, and `App`.<br>This aids service discovery, and cost allocation. | TBD | N/A |


### PR DESCRIPTION
It might be easier to review the [changes in rendered form](https://github.com/guardian/recommendations/blob/f30a93f21087abef4922676bb9dc88ccbd0fa565/best-practices.md).

## What is being recommended?
<!-- A brief description of what is being recommended here -->

Defines our best practices in tabular form.

## What's the context?
<!-- What lead to this recommendation being written, any context or [ADRs](https://docs.aws.amazon.com/prescriptive-guidance/latest/architectural-decision-records/adr-process.html) or related proposals. -->

We have a large number of best practices defined covering a vast spectrum of concerns, for example: AWS VPC usage; NPM module use; GitHub repository metadata; and AWS IAM users.

We have started to build tools to observe the adoption of these best practices. The logical extension to this, is to start flagging/alerting violations, at which point best practices become more like rules. For ease, “best practice” and “rule” will now be used interchangeably.

Currently, it is difficult to keep up to date with the rules as:
- Some of them are defined in prose within the [recommendations](https://github.com/guardian/recommendations) or [security-recommendations](https://github.com/guardian/security-recommendations) repository.
- Some are defined in tabular format within the [service-catalogue](https://github.com/guardian/service-catalogue/blob/main/packages/repocop/RepoRules.md) repository.
- Some are defined within [application code](https://github.com/guardian/security-hq/blob/main/hq/app/logic/IamUnrecognisedUsers.scala), or [dashboards](https://metrics.gutools.co.uk/d/ruxm1B9Gz/devx-node-usage?orgId=1).
- Some are defined via [email](https://groups.google.com/a/guardian.co.uk/g/engineering/c/c1KoYYy8wPY/m/1G-bGCstGAAJ).

Additionally, the mechanism to exempt a resource from a rule varies, for example: presence of an AWS tag; a note in the repository; implicit knowledge.

We do not have a process for creating a rule, and we do not have a single place to find them all.

This change takes inspiration from [CDK-Nag](https://github.com/cdklabs/cdk-nag/blob/main/RULES.md) and [AWS Security Hub](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-controls-reference.html), and defines our best practices in tabular form to make them easier to reference in reports, and also to quote. For example, in a PR review one could say:

```
Excellent following of GH-01! 👍🏽 
```

Or

```
This doesn't quite follow AWS-01. Should we do X?
```

Each rule has:
- ID (of form `area-number`)
- Name (possibly redundant as the ID field exists, this is a short, human readable, label)
- Owner (who is responsible for defining, and tracking)
- Description (what, and why)
- How to check compliance
- How to exempt

A [proposal](https://docs.google.com/document/d/1L4pKPYgm0qNCoiU1mlaP4Pzp_vnokujOhHuxshZ-7ak/edit#) for this has been discussed within DevX[^1].

## Notes and questions
1. This change does not enumerate _all_ our existing best practices. See 2 for reasons.
2. Writing markdown tables by hand is not fun! Should this PR be approved, I'll think of a lightweight way to introduce auto-generation of these tables. Initial thinking is YAML -> Markdown. Use of YAML allows for comments, and a schema for "type-checking".
3. Once 2 is solved, it'll be easier to enumerate all the existing best practices.
4. ❓ Is a markdown table the best format? Or should this be something different, such as HTML, or [AsciiDoc](https://asciidoc.org/)?

[^1]: If the linked Google Doc does not exist in future, apologies from the past!