### PR TITLE
Code review: knowledge sharing and readiness

### DIFF
--- a/pull-requests.md
+++ b/pull-requests.md
@@ -10,6 +10,8 @@ This last aspect is especially important in mono-repos as:
 - Multiple teams might be submitting changes to the repository
 - Some code changes may have non-obvious impact. For example, whether a code change directly or indirectly impacts data security. Understanding the impact of a change can be hard without the insight and input of a subject matter expert.
 
+Code review also allows for knowledge sharing in both directions between code authors and reviewers at all levels of experience. Reviewing PRs is a great way to understand a new codebase, and to stay in touch with what's happening in your team. And although a review might not be the best place for long discussions, reviews can help to surface new patterns and techniques for both code authors and reviewers.
+
 # The art of raising a PR
 > **Note**
 > See also the Additional resources below!

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -18,6 +18,11 @@ Code review also allows for knowledge sharing in both directions between code au
 
 The following are generally applicable to PRs, but are not hard rules.
 
+## Ready
+Read over your code before opening the PR for review. The main point of code review is to get a second perspective, but having a final look at your own code can help catch common mistakes, such as blocks of commented-out code or build files that shouldn't have been committed.
+
+Tip: Github allows you to open a PR in 'draft' state, which can often be helpful if you want to review your own code, or have remote CI checks run, before others review it. (Remember to change the status to `ready for review` later on though!)
+
 ## Small
 A PR should be easy to understand, and address a single concern.
 


### PR DESCRIPTION
## What is being recommended?

- Adds a paragraph on knowledge sharing in the discussion of the benefits of reviews.
- Adds a recommendation to read your code over before opening a PR, to catch low hanging fruit (e.g. common mistakes such as files which shouldn't have been committed).

## What's the context?

### Knowledge sharing 

There is already a line on knowledge sharing, but it emphasises the role of 'subject matter experts'. While subject matter experts have a distinctive role to play in certain reviews, I don't think that this captures the full knowledge-sharing benefits of code review, as it's practiced at The Guardian. In the new addition, I've tried to capture the fact that review provides opportunities for different kinds of learning, as well as the fact that much of this should be seen as happening among peers, and running in either direction (from author to reviewer, or vice versa).

### Re-reading your code before opening a PR

I don't especially imagine this recommendation to be particularly controversial. Although we don't want expect code authors to always submit 100% bug-free code, there is a class of mistakes that are easy to make, and generally easy to spot, like forgetting to delete commented-out code, or committing build/tooling files by accident. Catching these issues quicker means that they're quicker and easier to fix, and help reviewers to focus on the issues that the author might _not_ be able to easily spot.