### PR TITLE
Add docs link for PR status

### DIFF
--- a/pull-requests.md
+++ b/pull-requests.md
@@ -21,7 +21,7 @@ The following are generally applicable to PRs, but are not hard rules.
 ## Ready
 Read over your code before opening the PR for review. The main point of code review is to get a second perspective, but having a final look at your own code can help catch common mistakes, such as blocks of commented-out code or build files that shouldn't have been committed.
 
-Tip: Github allows you to open a PR in 'draft' state, which can often be helpful if you want to review your own code, or have remote CI checks run, before others review it. (Remember to change the status to `ready for review` later on though!)
+Tip: Github allows you to open a PR in `draft` state, which can often be helpful if you want to review your own code, or have remote CI checks run, before others review it. (Remember to [change the status of your PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review) to `ready for review` later on though!)
 
 ## Small
 A PR should be easy to understand, and address a single concern.


### PR DESCRIPTION
This doesn't add any new recommendations. It just standardises the kind of quotation marks used for PR statuses, and adds a link to the relevant part of the gh docs for changing PR status.

h/t @mxdvl https://github.com/guardian/recommendations/pull/121#discussion_r1192579000