### PR TITLE
feat: Generate the best practice Markdown

### DIFF
--- a/best-practice/README.md
+++ b/best-practice/README.md
@@ -1,0 +1,13 @@
+# Best Practice Generator
+This is a small [Deno](https://deno.com) TypeScript script to generate the [best practices markdown file](../best-practices.md).
+
+## Pre-requisites
+- [Deno](https://deno.com/manual/getting_started/installation)
+
+## Adding a new best practice
+To add a new best practice, follow these steps:
+1. Update [definitions.ts](definitions.ts). Before adding a best practice, consider:
+   - How one can identify if it's being followed (e.g. a dashboard, or a command to run)
+   - How to exempt from it
+2. Generate the markdown file via `./generate.sh` (this will also type-check, and format your changes)
+3. Raise a PR with your changes

--- a/best-practice/definitions.ts
+++ b/best-practice/definitions.ts
@@ -1,6 +1,6 @@
 import { IAllBestPractice, IBestPractice } from "./types.ts";
 
-const github: IBestPractice[] = [
+const github: readonly IBestPractice[] = [
   {
     name: "Default Branch Name",
     owner: "[@guardian](https://github.com/orgs/guardian/teams/all)",
@@ -9,9 +9,9 @@ const github: IBestPractice[] = [
     howToCheck: "Manual. View the repository on https://github.com",
     howToExempt: "N/A",
   },
-];
+] as const satisfies readonly IBestPractice[];
 
-const aws: IBestPractice[] = [
+const aws: readonly IBestPractice[] = [
   {
     name: "Resource Tagging",
     owner:
@@ -21,7 +21,7 @@ const aws: IBestPractice[] = [
     howToCheck: "TBD",
     howToExempt: "N/A",
   },
-];
+] as const satisfies readonly IBestPractice[];
 
 export const AllBestPractices: IAllBestPractice = {
   GitHub: github,

--- a/best-practice/definitions.ts
+++ b/best-practice/definitions.ts
@@ -1,0 +1,29 @@
+import { IAllBestPractice, IBestPractice } from "./types.ts";
+
+const github: IBestPractice[] = [
+  {
+    name: "Default Branch Name",
+    owner: "[@guardian](https://github.com/orgs/guardian/teams/all)",
+    description:
+      "The default branch name should be `main`.<br>See the [master-to-main tool](https://github.com/guardian/master-to-main/blob/main/migrating.md).",
+    howToCheck: "Manual. View the repository on https://github.com",
+    howToExempt: "N/A",
+  },
+];
+
+const aws: IBestPractice[] = [
+  {
+    name: "Resource Tagging",
+    owner:
+      "[DevX Operations](https://github.com/orgs/guardian/teams/devx-operations)",
+    description:
+      "AWS resources should be tagged (where supported) with `Stack`, `Stage`, and `App`.<br>This aids service discovery, and cost allocation.",
+    howToCheck: "TBD",
+    howToExempt: "N/A",
+  },
+];
+
+export const AllBestPractices: IAllBestPractice = {
+  GitHub: github,
+  AWS: aws,
+};

--- a/best-practice/generate.sh
+++ b/best-practice/generate.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+if ! command -v deno &> /dev/null
+then
+    echo "Deno could not be found. Please install Deno from https://deno.com/manual/getting_started/installation."
+    exit 1
+fi
+
+deno check "$DIR/index.ts"
+deno fmt "$DIR/*.ts"
+deno run --allow-read --allow-write "${DIR}/index.ts"

--- a/best-practice/index.ts
+++ b/best-practice/index.ts
@@ -1,0 +1,67 @@
+/**
+ * This script generates the best-practices.md file from the definitions in the definitions.ts file.
+ *
+ * Add new best practices to the definitions.ts file.
+ */
+
+import * as path from "https://deno.land/std/path/mod.ts";
+import { markdownTable } from "npm:markdown-table";
+import { AllBestPractices } from "./definitions.ts";
+
+const markdownFile = path.join(
+  path.dirname(path.fromFileUrl(import.meta.url)),
+  "..",
+  "best-practices.md",
+);
+
+const file = await Deno.readTextFile(markdownFile);
+
+const startMark = "<!-- contentstart -->";
+const endMark = "<!-- contentend -->";
+
+if (!file.includes(startMark) || !file.includes(endMark)) {
+  throw new Error(
+    `Could not find start (${startMark}) and end markers (${endMark}) in ${markdownFile}`,
+  );
+}
+
+const tableHeaderRow = [
+  "ID", // This will be auto-generated
+  "Name",
+  "Owner",
+  "Description",
+  "How to check compliance",
+  "How to exempt",
+];
+
+const markdownContent = Object.entries(AllBestPractices).flatMap(
+  ([section, bestPractices]) => {
+    const markdownH2 = `## ${section}`;
+
+    const tableRows = bestPractices.map((row, index) => {
+      const id = [
+        section,
+        (index + 1).toString().padStart(2, "0"),
+      ].join("-").toUpperCase();
+
+      return [id, ...Object.values(row)];
+    });
+
+    const table = markdownTable([tableHeaderRow, ...tableRows]);
+
+    return [markdownH2, table];
+  },
+);
+
+// Find text between markers and replace it with the start marker
+const re = new RegExp(`${startMark}(.|\n)*${endMark}`, "m");
+const resetFile = file.replace(re, startMark);
+
+// replace the now singular start marker with the start marker, content, and end marker
+const updatedFile = resetFile.replace(
+  startMark,
+  [startMark, ...markdownContent, endMark].join("\n"),
+);
+
+// save changes
+await Deno.writeTextFile(markdownFile, updatedFile);

--- a/best-practice/index.ts
+++ b/best-practice/index.ts
@@ -3,25 +3,20 @@
  *
  * Add new best practices to the definitions.ts file.
  */
-
-import * as path from "https://deno.land/std/path/mod.ts";
 import { markdownTable } from "npm:markdown-table";
 import { AllBestPractices } from "./definitions.ts";
 
-const markdownFile = path.join(
-  path.dirname(path.fromFileUrl(import.meta.url)),
-  "..",
-  "best-practices.md",
-);
+const markdownFilepath =
+  new URL(import.meta.resolve("../best-practices.md")).pathname;
 
-const file = await Deno.readTextFile(markdownFile);
+const file = await Deno.readTextFile(markdownFilepath);
 
 const startMark = "<!-- contentstart -->";
 const endMark = "<!-- contentend -->";
 
 if (!file.includes(startMark) || !file.includes(endMark)) {
   throw new Error(
-    `Could not find start (${startMark}) and end markers (${endMark}) in ${markdownFile}`,
+    `Could not find start (${startMark}) and end markers (${endMark}) in ${markdownFilepath}`,
   );
 }
 
@@ -64,4 +59,4 @@ const updatedFile = resetFile.replace(
 );
 
 // save changes
-await Deno.writeTextFile(markdownFile, updatedFile);
+await Deno.writeTextFile(markdownFilepath, updatedFile);

--- a/best-practice/index.ts
+++ b/best-practice/index.ts
@@ -48,15 +48,10 @@ const markdownContent = Object.entries(AllBestPractices).flatMap(
   },
 );
 
-// Find text between markers and replace it with the start marker
+// FInd the markers, and replace them, and any text in between, with the new content.
 const re = new RegExp(`${startMark}(.|\n)*${endMark}`, "m");
-const resetFile = file.replace(re, startMark);
-
-// replace the now singular start marker with the start marker, content, and end marker
-const updatedFile = resetFile.replace(
-  startMark,
+const updatedFile = file.replace(
+  re,
   [startMark, ...markdownContent, endMark].join("\n"),
 );
-
-// save changes
 await Deno.writeTextFile(markdownFilepath, updatedFile);

--- a/best-practice/types.ts
+++ b/best-practice/types.ts
@@ -1,0 +1,38 @@
+export interface IBestPractice {
+  /**
+   * The name of the best practice. Should be short.
+   */
+  name: string;
+
+  /**
+   * The team responsible for monitoring, and communicating this best practice.
+   *
+   * This field supports Markdown notation, allowing you to, for example, link to a team's GitHub page.
+   */
+  owner: string;
+
+  /**
+   * A description of the best practice, explaining why it's important.
+   *
+   * This field supports Markdown notation.
+   */
+  description: string;
+
+  /**
+   * How to check if the best practice is being followed.
+   *
+   * For example, a link to a dashboard, or a command to run.
+   */
+  howToCheck: string;
+
+  /**
+   * How to exempt from the best practice.
+   */
+  howToExempt: string;
+}
+
+/**
+ * A list of best practices, grouped by section.
+ * The section will be used as a heading in the Markdown file.
+ */
+export type IAllBestPractice = Record<string, IBestPractice[]>;

--- a/best-practice/types.ts
+++ b/best-practice/types.ts
@@ -35,4 +35,4 @@ export interface IBestPractice {
  * A list of best practices, grouped by section.
  * The section will be used as a heading in the Markdown file.
  */
-export type IAllBestPractice = Record<string, IBestPractice[]>;
+export type IAllBestPractice = Record<string, readonly IBestPractice[]>;

--- a/best-practices.md
+++ b/best-practices.md
@@ -1,18 +1,18 @@
 <!--
-Before adding a best practice, consider:
-  - How one can identify if it's being followed (e.g. a dashboard)
-  - How to exempt from it
+This file is auto-generated via `best-practice/generate.sh`.
+Do not edit it directly, but instead run `./best-practice/generate.sh`.
 -->
 
 # Best Practices
 This document defines a list of best practices we have defined. 
 
+<!-- contentstart -->
 ## GitHub
-| ID | Name | Owner         | Description                                                                                                                                     | How to check compliance                           | How to exempt |
-| -- | ---- |---------------|-------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------|---------------|
-| GH-01 | DefaultBranchName | [@guardian](https://github.com/orgs/guardian/teams/all) | The default branch name should be `main`.<br>See the [master-to-main tool](https://github.com/guardian/master-to-main/blob/main/migrating.md). | Manual. View the repository on https://github.com | N/A |
-
+| ID        | Name                | Owner                                                   | Description                                                                                                                                    | How to check compliance                           | How to exempt |
+| --------- | ------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- | ------------- |
+| GITHUB-01 | Default Branch Name | [@guardian](https://github.com/orgs/guardian/teams/all) | The default branch name should be `main`.<br>See the [master-to-main tool](https://github.com/guardian/master-to-main/blob/main/migrating.md). | Manual. View the repository on https://github.com | N/A           |
 ## AWS
-| ID | Name | Owner         | Description                                                                                                                                     | How to check compliance                           | How to exempt |
-| -- | ---- |---------------|-------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------|---------------|
-| AWS-01 | Tagging | [DevX Operations](https://github.com/orgs/guardian/teams/devx-operations) | AWS resources should be tagged (where supported) with `Stack`, `Stage`, and `App`.<br>This aids service discovery, and cost allocation. | TBD | N/A |
+| ID     | Name             | Owner                                                                     | Description                                                                                                                             | How to check compliance | How to exempt |
+| ------ | ---------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | ------------- |
+| AWS-01 | Resource Tagging | [DevX Operations](https://github.com/orgs/guardian/teams/devx-operations) | AWS resources should be tagged (where supported) with `Stack`, `Stage`, and `App`.<br>This aids service discovery, and cost allocation. | TBD                     | N/A           |
+<!-- contentend -->


### PR DESCRIPTION
This follows on from #119.

## What is being ~recommended~ changed?
Use [Deno](https://deno.com/) for a lightweight script to generate a Markdown table, and inject it into best-practice.md.

The TypeScript type-system allows for a schema to be created, allowing each best practice to render the same way.

## What's the context?
In #119 I commented:

> Writing markdown tables by hand is not fun!

This is still true! I also commented:

> I'll think of a lightweight way to introduce auto-generation of these tables. Initial thinking is YAML -> Markdown. Use of YAML allows for comments, and a schema for "type-checking".

Alas, converting YAML to a Markdown table wasn't quite as simple as this Deno script. The script still provides the same benefits of allowing for comments, and type-checking.

There are two downsides to this solution:
1. A requirement to install Deno. However, I'd suggest this is easier to maintain vs. the bash needed for the YAML version.
2. An understanding of TypeScript. However, I'd suggest this is minimal as only `definitions.ts` needs updating, and the IDE should pick up the added doc strings to offer IntelliSense.

Lastly, in #119 @mxdvl [commented](https://github.com/guardian/recommendations/pull/119#issuecomment-1539742128) that CSVs are supported by GitHub, and better-suited at tabular data. Whilst this is true, Markdown tables offer richer formatting, such as links.