### PR TITLE
explain architecture decision records

### DIFF
--- a/RFCs.md
+++ b/RFCs.md
@@ -21,6 +21,6 @@ This will help readers to more easily understand your rationale.
 Comments on Google docs or GitHub discussions are good ways of collecting people's thoughts alongside your original proposal.
 
 ## How to comment on an RFC
-A RFC is a request for help – someone is asking for your insight and the benefit of your experience. Be candid but be kind. Ultimately, the aim is to collaborate until collectively, we arrive at the best possible version of the idea.
+An RFC is a request for help – someone is asking for your insight and the benefit of your experience. Be candid but be kind. Ultimately, the aim is to collaborate until collectively, we arrive at the best possible version of the idea.
 
 At the same time, remember you are being asked for help. No one is trying to embarrass you! It’s a test of ideas, not the people who have them. There are no wrong comments – the more contributors to an RFC, the more effective they are.

--- a/RFCs.md
+++ b/RFCs.md
@@ -1,0 +1,26 @@
+# RFCs
+RFCs (requests for comments) are a way of soliciting feedback on a proposal from your peers. They allow for asynchronous discussion around a topic, and can also act as a decision record.
+
+You can think of them as PRs for ideas.
+
+## How to write an RFC
+Before writing a full RFC, it can be useful to run your thoughts past a few close colleagues. While the purpose of an RFC is to test your ideas, you will get better feedback if you can deal with any immediate issues before presenting something to a wider audience.
+
+Be mindful that you will be asking people to invest their time to read, consider and respond to your proposal. The easier (and quicker) it is to understand what you're proposing, the more likely you are to get useful feedback. 
+
+Remember, too, that it is a request for comments, not compliments! People may not agree with your proposal. This is good! This is what you want to know!
+
+When you are ready, provide a clear description of:
+
+1. The problem you want to solve
+2. Why the status quo does not address the problem
+3. A proposed solution
+
+This will help readers to more easily understand your rationale.
+
+Comments on Google docs or GitHub discussions are good ways of collecting people's thoughts alongside your original proposal.
+
+## How to comment on an RFC
+A RFC is a request for help – someone is asking for your insight and the benefit of your experience. Be candid but be kind. Ultimately, the aim is to collaborate until collectively, we arrive at the best possible version of the idea.
+
+At the same time, remember you are being asked for help. No one is trying to embarrass you! It’s a test of ideas, not the people who have them. There are no wrong comments – the more contributors to an RFC, the more effective they are.

--- a/architecture-decision-records.md
+++ b/architecture-decision-records.md
@@ -1,0 +1,15 @@
+# ADRs
+
+Software engineering and system design are often a collaboration effort and, in particular, the decisions that shape a project often arise as [RFCs](RFCs.md), but once the RFC has been... well, commented on, how do we articulate and present the decisions that come of out them? 
+
+Enter the architecture decision records, ADRs for short.
+
+Joel Parker Henderson has a [detailed presentation of ADRs](https://github.com/joelparkerhenderson/architecture-decision-record), but for the purpose of this text, an architecture decision record (ADR) is a document that captures an important architectural decision made along with its context and consequences.
+
+Often, ADRs help people who come to projects after the original designers understand 
+
+1. THE conditions that they observe are not accidental but, instead, were the result to purposeful decisions (for instance the choice of programming languages, the use of specific libraries or the adoption of specific software patterns).
+
+1. The explanation of why those decisions where made, including but not limited to which constraints lead to them and, if relevant, in which conditions they could be reconsidered.
+
+One example at the guardian of a system that has incorporated ADRs from the beginning if its life is dotcom-rendering. You can access and read them [here](https://github.com/guardian/dotcom-rendering/tree/main/dotcom-rendering/docs/architecture).

--- a/architecture-decision-records.md
+++ b/architecture-decision-records.md
@@ -1,12 +1,15 @@
 # ADRs
 
-Software engineering and system design are often a collaboration effort and, in particular, the decisions that shape a project often arise as [RFCs](RFCs.md), but once the RFC has been... well, commented on, how do we articulate and present the decisions that come of out them? 
+Software engineering and system design are often a collaboration effort and, in particular, the decisions that shape a project often arise as [RFCs](RFCs.md), but once the RFC has been... well, commented on, how do we articulate and present the decisions that come of out them?
 
-Enter the architecture decision records, ADRs for short.
+Enter the architecture decision record, ADR for short. In a nutshell an ADR is a document that captures an important architectural decision that was made, along with its context and consequences.
 
-Joel Parker Henderson has a [detailed presentation of ADRs](https://github.com/joelparkerhenderson/architecture-decision-record), but for the purpose of this text, an architecture decision record (ADR) is a document that captures an important architectural decision made along with its context and consequences.
+Excellent in-depth introductions to ADRs are:
 
-Often, ADRs help people who come to projects after the original designers understand 
+- [Github's explanation of ADRs](https://adr.github.io/)
+- [Joel Parker Henderson's detailed presentation of ADRs](https://github.com/joelparkerhenderson/architecture-decision-record) 
+
+Often, ADRs help people who come to projects after the original designers understand:
 
 1. THE conditions that they observe are not accidental but, instead, were the result to purposeful decisions (for instance the choice of programming languages, the use of specific libraries or the adoption of specific software patterns).
 

--- a/github.md
+++ b/github.md
@@ -86,7 +86,7 @@ Things we could happily put on the front page of the Guardian.
 Examples:
   - source code
   - diagrams
-  - architecture decision records
+  - [architecture decision records](architecture-decision-records.md)
 
 ### Private information
 Things we do not want to be common knowledge, but knowing them does not directly compromise anything.


### PR DESCRIPTION
## What is being recommended?

This presents and briefly explain architecture decisions records, notably in the context of them being the natural long term outcome of rfcs ( https://github.com/guardian/recommendations/pull/125 ). 
