### PR TITLE
fix(npm): Use guardian/github-secret-access to vend NPM_TOKEN

### DIFF
--- a/npm-packages.md
+++ b/npm-packages.md
@@ -326,13 +326,7 @@ Although `@guardian/libs` is at v6.5.2 in the repo and would work fine, we still
 
 Prefer continuous delivery from GitHub using [Changesets](https://github.com/changesets/changesets).
 
-Use the org secret `NPM_TOKEN` to publish to NPM. This will publish the package from our [`guardian-developers`](https://www.npmjs.com/~guardian-developers) NPM account. NPM tokens are provided by the DevX team on a repo by repo basis.
-
-> This account is managed under npm@theguardian.com by the devex stream.
-
-#### Spontaneous publishing
-
-If you do not use Changesets, publish manually from the command line using [np](https://www.npmjs.com/package/np).
+Use the org secret `NPM_TOKEN` to publish to NPM. This will publish the package from our [`guardian-developers`](https://www.npmjs.com/~guardian-developers) NPM account (managed by CSTI). The `NPM_TOKEN` secret is provided on a repo by repo basis via https://github.com/guardian/github-secret-access.
 
 ## Using `@guardian` NPM packages
 


### PR DESCRIPTION
## What is being recommended?
Updates the process for getting access to the organisational `NPM_TOKEN` secret, which is now automated via https://github.com/guardian/github-secret-access.

## What's the context?
See the [README of https://github.com/guardian/github-secret-access](https://github.com/guardian/github-secret-access/blob/main/README.md).

> **Note**
> 
> The recommendations in this repository are intended to share engineering best practices for all of Product & Engineering (P&E) in the open. 
> 
> Some considerations:
>  - Should this really be an ADR in another repository?
>  - Have you sought review widely enough (Developer Experience, Heads of Engineering)? 
>  - If it is security related, should you consult with Information Security?
