### PR TITLE
Focus on solution over problem in Scala recommendations

### DIFF
--- a/scala.md
+++ b/scala.md
@@ -7,15 +7,14 @@
  * If some dependencies are unavailable for the latest version, it is acceptable to use the latest patch version of the previous minor version but try to avoid it. If you have a dependency that isn't available for one of these versions, it's effectively dead and you should plan how to move away from it.
  * If you come to a codebase using an older version of Scala, it should be upgraded before any new features are added.
  * Run on a Corretto LTS version of Java, no lower than Java 11. At the time of writing this means Corretto 11 or 17. For tips on upgrading from Java 8, see [here](https://docs.google.com/document/d/1ZR-YnaXCT5_gLVmTCeGs0mWd3KPaAozPjQK8uUzHZ9w/edit?usp=sharing).
- * Avoid dependency injection in general.
+ * Prefer [passing dependencies as function parameters](http://debasishg.blogspot.com/2011/03/pushing-envelope-on-oo-and-functional.html) over [dependency injection](https://en.wikipedia.org/wiki/Dependency_injection)[^1]. This enable [referential transparency](https://en.wikipedia.org/wiki/Referential_transparency) of your programs.
+   
 
-[Dependency injection](https://en.wikipedia.org/wiki/Dependency_injection) is a software design pattern that implements [inversion of control](https://en.wikipedia.org/wiki/Inversion_of_control) between a `client` and a `service` for resolving dependencies. The term `injection` refers to a third party (named `the injector`) which is responsible for constructing the services and injecting them into the client. Usual `injectors`are dependency injection frameworks such as `guice`, `dagger`, `macwire`, `spring`.
-
-Instead of `injecting` your dependencies, you should simply [pass them as parameters](http://debasishg.blogspot.com/2011/03/pushing-envelope-on-oo-and-functional.html) of functions you are calling. This enable [referential transparency](https://en.wikipedia.org/wiki/Referential_transparency) of your programs.
-
-Most of the time, dependency injection does not solve a real business problem. You don't need to have a single place where you define which concrete instance your trait should be used. This is `accidental complexity`, as coined by Fred Brooks in [No Silver Bullet](https://en.wikipedia.org/wiki/No_Silver_Bullet)
-
-With [The play framework](https://www.playframework.com/) you should always use [compile-time dependency injection](https://www.playframework.com/documentation/2.5.x/ScalaCompileTimeDependencyInjection) which refers to an object oriented way to specify your components declaratively in scala.
+[^1]: Dependency injection is a software design pattern that implements [inversion of control](https://en.wikipedia.org/wiki/Inversion_of_control) between a `client` and a `service` for resolving dependencies. The term `injection` refers to a third party (named `the injector`) which is responsible for constructing the services and injecting them into the client. Usual `injectors`are dependency injection frameworks such as `guice`, `dagger`, `macwire`, `spring`. 
+      
+      Most of the time, dependency injection does not solve a real business problem. You don't need to have a single place where you define which concrete instance your trait should be used. This is `accidental complexity`, as coined by Fred Brooks in [No Silver Bullet](https://en.wikipedia.org/wiki/No_Silver_Bullet)
+      
+      With [The play framework](https://www.playframework.com/) you should always use [compile-time dependency injection](https://www.playframework.com/documentation/2.5.x/ScalaCompileTimeDependencyInjection) which refers to an object oriented way to specify your components declaratively in scala.
 
 
 ## Continuous dependency management


### PR DESCRIPTION
## What is being recommended?

Nothing new, but the Scala recommendations are refactored to focus on the solution rather that the problem.

Relegate the discussion on dependency injection to a footnote.

## What's the context?

Focus on the preferred solution over what we do not recommend. People want to solve problems, not be told off.

Original wording in #19

Pinging @guardian/scala who may want to chime in

## Images

The bullet is more consice and contains a footnote:

<img width="987" alt="image" src="https://github.com/guardian/recommendations/assets/76776/145ced40-ca4c-49a7-9730-51c36e463f9b">

Then at the bottom of the document:

<img width="1028" alt="image" src="https://github.com/guardian/recommendations/assets/76776/3c2641c9-f526-437f-8139-fb14bbb70e63">
