### PR TITLE
Copy the inclusive communication guide from our engineering culture repository

### DIFF
--- a/inclusive-communication.md
+++ b/inclusive-communication.md
@@ -1,0 +1,56 @@
+# Guidelines for inclusive communication
+
+The purpose of these guidelines are to provide some best practices and examples of inclusive communication. Just like many other best practices, you may be referred to these guidelines by your colleagues as part of code reviews, feedback sessions, document comments, and retrospectives, etc, so please do take time to digest them effectively. They are relevant to all forms of communication including verbal, written, drawing and code.
+
+Please do submit any edits you feel necessary, and these will be reviewed and merged by a member of the EM team.
+
+## Why is inclusive language important?
+
+*   Makes people feel naturally included
+*   Doesn’t trigger memories of someones’ prior trauma
+*   Brings more individuals within the perceived normality
+*   Helps overcome rather than cement peoples’ cognitive biases
+
+## Some examples
+
+#### From [Twitter Engineering on 2 July](https://twitter.com/TwitterEng/status/1278733305190342656)
+
+| **Non-inclusive** | **Alternatives** |
+|---|---|
+| Whitelist | Allowlist |
+| Blacklist | Denylist |
+| Master/slave | Leader/follower, primary/replica, primary/standby |
+| Grandfathered | Legacy status |
+| Gendered pronouns (e.g. guys) | Folks, people, you all, y'all |
+| Gendered pronouns (e.g. he/him/his) | They, them, their |
+| Man hours | Person hours, engineering hours |
+| Sanity check | Quick check, confidence check, coherence check |
+| Dummy value | Placeholder value, sample value |
+
+#### From P&E - Engineering
+
+|  **Non-inclusive**   | **Alternatives** |
+| -------------------- | ---------------- |
+| Blackbox             | Closed / Opaque box |
+| Whitebox             | Open / Clear box |
+| God mode             | Staff mode / CSR mode / Admin mode |
+| Back of a fag packet | Back of an envelope/napkin |
+| Straw man            | Straw person/head |
+| mental               | unbelievable/horrible |
+
+#### Longer list from DialPad
+https://github.com/dialpad/inclusive-language
+  
+
+## Accountability
+
+It can be difficult to suddenly stop using words that have been in general circulation for many years, and it’s understandable that people will still use them accidentally. How you react to repair your miscommunication is far more important than whether you made it or not.
+
+If you would like to cement the improvements in both your own and your team’s mind, a good way to do it is by spending some time reviewing existing materials and making changes. See the associated resources below.
+
+## Dignity at Work
+
+GNM takes deliberate or repeated use of non-inclusive language very seriously, so if you are aware of this happening, please report it to a manager or HR as normal. GNM’s Dignity at Work policy can be found in the [GNM Employee Handbook](https://drive.google.com/file/d/1bCE8b68Or6E7xnS7kqwSk1cL0h7byC56/).
+
+## Associated resources
+*   The [GNM Employee Handbook](https://drive.google.com/file/d/1bCE8b68Or6E7xnS7kqwSk1cL0h7byC56/) has a section on WorkingTogether which covers GNM’s Equality and diversity, Trans equality and Dignity at Work policies.

--- a/inclusive-communication.md
+++ b/inclusive-communication.md
@@ -13,34 +13,34 @@ Please do submit any edits you feel necessary, and these will be reviewed and me
 
 ## Some examples
 
-#### From [Twitter Engineering on 2 July](https://twitter.com/TwitterEng/status/1278733305190342656)
+### From [Twitter Engineering in 2020](https://twitter.com/TwitterEng/status/1278733305190342656)
 
-| **Non-inclusive** | **Alternatives** |
-|---|---|
-| Whitelist | Allowlist |
-| Blacklist | Denylist |
-| Master/slave | Leader/follower, primary/replica, primary/standby |
-| Grandfathered | Legacy status |
-| Gendered pronouns (e.g. guys) | Folks, people, you all, y'all |
-| Gendered pronouns (e.g. he/him/his) | They, them, their |
-| Man hours | Person hours, engineering hours |
-| Sanity check | Quick check, confidence check, coherence check |
-| Dummy value | Placeholder value, sample value |
+| **Non-inclusive**                   | **Alternatives**                                  |
+|-------------------------------------|---------------------------------------------------|
+| Whitelist                           | Allowlist                                         |
+| Blacklist                           | Denylist                                          |
+| Master/slave                        | Leader/follower, primary/replica, primary/standby |
+| Grandfathered                       | Legacy status                                     |
+| Gendered pronouns (e.g. guys)       | Folks, people, you all, y'all                     |
+| Gendered pronouns (e.g. he/him/his) | They, them, their                                 |
+| Man hours                           | Person hours, engineering hours                   |
+| Sanity check                        | Quick check, confidence check, coherence check    |
+| Dummy value                         | Placeholder value, sample value                   |
 
-#### From P&E - Engineering
+### From P&E - Engineering
 
-|  **Non-inclusive**   | **Alternatives** |
-| -------------------- | ---------------- |
-| Blackbox             | Closed / Opaque box |
-| Whitebox             | Open / Clear box |
+| **Non-inclusive**    | **Alternatives**                   |
+|----------------------|------------------------------------|
+| Blackbox             | Closed / Opaque box                |
+| Whitebox             | Open / Clear box                   |
 | God mode             | Staff mode / CSR mode / Admin mode |
-| Back of a fag packet | Back of an envelope/napkin |
-| Straw man            | Straw person/head |
-| mental               | unbelievable/horrible |
+| Back of a fag packet | Back of an envelope/napkin         |
+| Straw man            | Straw person/head                  |
+| mental               | unbelievable/horrible              |
 
-#### Longer list from DialPad
+### Longer list from DialPad
+
 https://github.com/dialpad/inclusive-language
-  
 
 ## Accountability
 
@@ -53,4 +53,5 @@ If you would like to cement the improvements in both your own and your team’s 
 GNM takes deliberate or repeated use of non-inclusive language very seriously, so if you are aware of this happening, please report it to a manager or HR as normal. GNM’s Dignity at Work policy can be found in the [GNM Employee Handbook](https://drive.google.com/file/d/1bCE8b68Or6E7xnS7kqwSk1cL0h7byC56/).
 
 ## Associated resources
+
 *   The [GNM Employee Handbook](https://drive.google.com/file/d/1bCE8b68Or6E7xnS7kqwSk1cL0h7byC56/) has a section on WorkingTogether which covers GNM’s Equality and diversity, Trans equality and Dignity at Work policies.


### PR DESCRIPTION
I’ve looked for [the inclusive communication guide](https://github.com/guardian/our-engineering-culture/blob/main/inclusive-communication.md) before and found it hard to find because I always look here, forgetting it’s in another repository. I think covering ~engineering culture and~ inclusive communication in our recommendations seems like a good fit, and then the info is in one place.

(Note I’ve made minor tweaks to the files in the process of copying them over, which I’ve put in a separate commit for ease of review.)