### PR TITLE
Describe the `gu:repo` tag

### DIFF
--- a/AWS.md
+++ b/AWS.md
@@ -11,6 +11,7 @@ General
      * `CODE` for pre-production
      * `INFRA` for infrastructure or singleton resources e.g. [elasticsearch-node-rotation](https://github.com/guardian/elasticsearch-node-rotation)
    * `App` - the individual service e.g. `image-loader`
+   * `gu:repo` - the GitHub repository where the resource's definition can be found
  * If a resource needs to be shared across multiple environments, prefer to define it in it's own CFN template as the same resource cannot be defined in multiple templates
  * Prefer continuous delivery of infrastructure via Riff-Raff over manual deployment
    * This provides a better audit trail


### PR DESCRIPTION
## What is being recommended?
The `gu:repo` tag is part of our standard AWS tags - add it to the recommendations page, as a useful point of reference.

## What's the context?
@guardian/devx-operations are drafting some comms about the enablement of the [AWS Resource Tagging Standard](https://docs.aws.amazon.com/securityhub/latest/userguide/standards-tagging.html) across the estate. The recommendations repository is a useful resource to reference when describing the tagging schema.