### PR TITLE
Fix incorrect link in accessibility recos

### DIFF
--- a/accessibility.md
+++ b/accessibility.md
@@ -12,7 +12,7 @@ Aim to build user interfaces that:
 - Give [enough time][] to read and use
 - Do not [trigger seizures or physical reactions](https://www.w3.org/TR/WCAG21/#seizures-and-physical-reactions)
 - Are [navigable](https://www.w3.org/TR/WCAG21/#navigable)
-- Are [predictable](https://www.w3.org/TR/WCAG21/#navigable)
+- Are [predictable](https://www.w3.org/TR/WCAG21/#predictable)
 - Help users [avoid or correct mistakes](https://www.w3.org/TR/WCAG21/#input-assistance)
 - Are [compatible][] with existing or future users agents and assistive technologies
 


### PR DESCRIPTION
## What is being recommended?

This is a fix for an incorrect link. `predictable` links to the `navigable` guidelines.
