### PR TITLE
Reference the whole WCAG standard

### DIFF
--- a/accessibility.md
+++ b/accessibility.md
@@ -2,22 +2,19 @@
 
 ## Compliance
 
-We use a subset of the WCAG 2.1 AA standards as our benchmark for accessible products.
+We use compliance with WCAG 2.1 AA standards as our benchmark for accessible products.
 
-Aim to build user interfaces that:
+As a starting point, we aim to build user interfaces that:
 
 - Provide [text alternatives](https://www.w3.org/TR/WCAG21/#text-alternatives)
 - Are [adaptable](https://www.w3.org/TR/WCAG21/#adaptable)
 - Are [distinguishable](https://www.w3.org/TR/WCAG21/#distinguishable)
-- Give [enough time][] to read and use
+- Give [enough time](https://www.w3.org/TR/WCAG21/#enough-time) to read and use
 - Do not [trigger seizures or physical reactions](https://www.w3.org/TR/WCAG21/#seizures-and-physical-reactions)
 - Are [navigable](https://www.w3.org/TR/WCAG21/#navigable)
 - Are [predictable](https://www.w3.org/TR/WCAG21/#navigable)
 - Help users [avoid or correct mistakes](https://www.w3.org/TR/WCAG21/#input-assistance)
-- Are [compatible][] with existing or future users agents and assistive technologies
-
-[enough time]: https://www.w3.org/TR/WCAG21/#enough-time
-[compatible]: https://www.w3.org/TR/WCAG21/#compatible
+- Are [compatible](https://www.w3.org/TR/WCAG21/#compatible) with existing or future users agents and assistive technologies
 
 For web-based products, ensure your interfaces:
 


### PR DESCRIPTION
## What is being recommended?

Recommending the whole WCAG AA standard as our benchmark. I believe that we do currently see ourselves as accountable to WCAG AA in the department, and that we're right to do so.

If I understand correctly then the original reason for mentioning 'a subset' was to prevent the recommendation from feeling too overwhelming for readers who are new to the standard (which is quite detailed, and not always the most user-friendly for newcomers). In light of this, I've explicitly reframed the list of core principles as a starting point, which should hopefully point people in the direction of the most impactful parts of the spec, if they're new to the topic.

<!-- A brief description of what is being recommended here -->

## What's the context?

<!-- What lead to this recommendation being written, any context or [ADRs](https://docs.aws.amazon.com/prescriptive-guidance/latest/architectural-decision-records/adr-process.html) or related proposals. -->

> **Note**
> 
> The recommendations in this repository are intended to share engineering best practices for all of Product & Engineering (P&E) in the open. 
> 
> Some considerations:
>  - Should this really be an ADR in another repository?
>  - Have you sought review widely enough (Developer Experience, Heads of Engineering)? 
>  - If it is security related, should you consult with Information Security?
