### PR TITLE
refactor: replace links/mentions of security hq

### DIFF
--- a/ownership.md
+++ b/ownership.md
@@ -38,7 +38,7 @@ authentication, network security, encryption, secret management. Expert guidance
 
 The broad expectations of ongoing maintenance of a production application are:
 1. Security vulnerabilities are [addressed](/security.md#vulnerability-management) *as a priority*
-1. Dependencies are [kept up to date](https://github.com/guardian/security-hq/blob/73d5174a49efcfda009c804305d748edced6a8af/hq/markdown/vulnerability-management.md#vulnerabilities-via-3rd-party-libraries), so that security patching requirements can be met efficiently
+1. Dependencies are [kept up to date](https://github.com/guardian/security-recommendations/blob/main/recommendations/vulnerability-management.md#vulnerabilities-via-3rd-party-libraries), so that security patching requirements can be met efficiently
 1. Unused functionality is removed
 1. Impaired functionality is addressed, with priority determined by its importance
 1. Costs are monitored. [Baseline monitoring](https://github.com/guardian/aws-cost-management) is added globally

--- a/security.md
+++ b/security.md
@@ -9,15 +9,14 @@ This document contains general public security recommendations, for further inte
 
 ## Vulnerability management
 You should 
-[perform due diligence](https://github.com/guardian/security-hq/blob/main/hq/markdown/vulnerability-management.md) 
+[perform due diligence](https://github.com/guardian/security-recommendations/blob/main/recommendations/vulnerability-management.md) 
 on your platforms to minimise common vulnerabilities in infrastructure 
 and applications. Some of these vulnerabilities are not possible to fix 
 automatically, so your team should plan to spend time on addressing them 
 on a regular basis. 
 
 More detailed guidance is provided in 
-[Security HQ's documentation](https://github.com/guardian/security-hq/blob/main/hq/markdown/vulnerability-management.md) 
-(our central tool for security information.)
+[Security Recommendations](https://github.com/guardian/security-recommendations).
 
 ## Sensitive data
 


### PR DESCRIPTION
## What is being recommended?

Replaces links to Security HQ docs which have moved to Security Recommendations repo.

## What's the context?

Security HQ is being deprecated.

> **Note**
> 
> The recommendations in this repository are intended to share engineering best practices for all of Product & Engineering (P&E) in the open. 
> 
> Some considerations:
>  - Should this really be an ADR in another repository?
>  - Have you sought review widely enough (Developer Experience, Heads of Engineering)? 
>  - If it is security related, should you consult with Information Security?
