### PR TITLE
docs: stop recommending storing creds in S3

### DIFF
--- a/AWS.md
+++ b/AWS.md
@@ -21,7 +21,7 @@
 
  * Applications should use IAM instance profiles to gain access to other AWS resources. 
  * Such profiles should be associated with roles that provide the minimum necessary rights.
- * Non-AWS credentials should be stored in Parameter Store, DynamoDB or S3, so that they can be retrieved via an IAM role.
+ * Non-AWS credentials should be stored in Parameter Store or DynamoDB, so that they can be retrieved via an IAM role.
 
 ## EC2
 


### PR DESCRIPTION
## What is being recommended?

We should no longer be recommending the storing of credentials in S3, so this has been removed from `aws.md`.

## What's the context?

For improved security.
