### PR TITLE
Add recommendations on Publishing libraries to Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ This repository document [principles](#principles), standards and [guidelines](#
 -   [GitHub](github.md)
 -   [Github Actions](github-actions.md)
 -   [Logging](logging.md)
--   [NPM packages](npm-packages.md)
+- Publishing software libraries
+  - [NPM packages](npm-packages.md)
+  - [Maven Central for Scala, Kotlin & other JVM-based languages](publishing-libraries-to-maven-central.md)
 -   [Production Services, Ownership and Maintenance](ownership.md)
 -   [Pull requests](pull-requests.md)
 -   [Resiliency and Robustness](resiliency.md)

--- a/publishing-libraries-to-maven-central.md
+++ b/publishing-libraries-to-maven-central.md
@@ -1,0 +1,36 @@
+# Publishing libraries to Maven Central
+
+[Maven Central](https://central.sonatype.com/), administered by [Sonatype](https://www.sonatype.com/),
+is the de-facto artifact repository for JVM-based languages like Scala & Kotlin - for Typescript/JavaScript,
+the equivalent would be the [npm Registry](npm-packages.md).
+
+At the Guardian we publish many libraries to Maven Central, and are standardising on reusable automated
+GitHub Action release workflows with these aims:
+
+* **achieve zero-onboarding for new developers**: Any developer who has `write` access to a repo should be able
+  to publish a release of the library, at the click of a button.
+* **securely handle release credentials** - only allow access to release credentials for parts of the release process
+  that [_need_](https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/security-design.md) them.
+* **automated version compatibility checking** - to avoid [binary-incompatibility causing runtime errors](https://github.com/guardian/facia-scala-client/issues/301).
+* **reduce per-repo config** - adding library-publishing to a repo should add _minimal_ boilerplate.
+
+## Admin access
+
+As our automated GitHub Action workflows provide all the access that most users need, we have
+[very few user accounts](https://docs.google.com/spreadsheets/d/1B_XYsuxNwBuvJ9o72iqgerSeql97bEJw5pT9P5i9A5E/edit?usp=sharing)
+with direct admin access to Maven Central/Sonatype. If necessary, see the [docs](https://docs.google.com/document/d/1zA8CHa1a8faemorWokUlbkdexYzpilalqcPFwkRu92M/edit?usp=sharing)
+on credential rotation & account recovery.
+
+# Scala libraries
+
+Scala is our most common language for JVM-language artifacts. Any Guardian repo publishing a library
+should use [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow),
+which provides many lovely [benefits & features](https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/benefits.md).
+
+See [how to configure a repo to use the workflow](https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/configuration.md).
+
+# Kotlin libraries
+
+We're working on adopting a similar approach for our Android/Kotlin libraries, see eg:
+
+* https://github.com/guardian/source-apps/pull/10


### PR DESCRIPTION
## What is being recommended?

The main message is that Scala projects should use [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow) to publish to Maven Central, as we've [standardised](https://github.com/guardian/gha-scala-library-release-workflow/issues/20) on it and it does [all the right things](https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/benefits.md):

* **achieve zero-onboarding for new developers**: Any developer who has `write` access to a repo should be able
  to publish a release of the library, at the click of a button.
* **securely handle release credentials** - only allow access to release credentials for parts of the release process
  that [_need_](https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/security-design.md) them.
* **automated version compatibility checking** - to avoid [binary-incompatibility causing runtime errors](https://github.com/guardian/facia-scala-client/issues/301).
* **reduce per-repo config** - adding library-publishing to a repo should add _minimal_ boilerplate.

As Scala is not the only JVM-language that we publish to Maven Central- we have several Android/Kotlin projects! - I've tried to make the document generally applicable for publishing to Maven Central, regardless of JVM-based language.

## What's the context?

<!-- What lead to this recommendation being written, any context or [ADRs](https://docs.aws.amazon.com/prescriptive-guidance/latest/architectural-decision-records/adr-process.html) or related proposals. -->

The prompt to do this now comes from our plan to significantly reduce the number of [users with admin access to Sonatype](https://docs.google.com/spreadsheets/d/1B_XYsuxNwBuvJ9o72iqgerSeql97bEJw5pT9P5i9A5E/edit?usp=sharing) to a minimal number - @davidfurey suggested it would be a good idea to have clear documentation for other developers about who the remaining admins are, in the case of an emergency! So this documentation provides that, along with other guidance about publishing to Maven Central.

The Google Drive documents for those details, linked to from this public markdown doc, are _not_ public, but have constrained access appropriate to their audience.
