### PR TITLE
Remove reference to Twitter inclusive language guidelines

### DIFF
--- a/inclusive-communication.md
+++ b/inclusive-communication.md
@@ -13,8 +13,6 @@ Please do submit any edits you feel necessary, and these will be reviewed and me
 
 ## Some examples
 
-### From [Twitter Engineering in 2020](https://twitter.com/TwitterEng/status/1278733305190342656)
-
 | **Non-inclusive**                   | **Alternatives**                                  |
 |-------------------------------------|---------------------------------------------------|
 | Whitelist                           | Allowlist                                         |


### PR DESCRIPTION
## What is being recommended?

Remove the reference to a thread by Twitter engineering on Inclusive language.

## What's the context?

Twitter is perhaps not the best source to talk about inclusive language anymore given its current leadership! I don't recommend scrolling down on the linked Twitter thread!