### PR TITLE
Adds `gu:tool` and `gu:application-repo` definitions to AWS tags glossary

### DIFF
--- a/AWS.md
+++ b/AWS.md
@@ -10,7 +10,9 @@
      * `CODE` for pre-production
      * `INFRA` for infrastructure or singleton resources e.g. [elasticsearch-node-rotation](https://github.com/guardian/elasticsearch-node-rotation)
    * `App` - the individual service e.g. `image-loader`
+   * `gu:tool` - the tool which the resource belongs to, similar to stack but more specific e.g. Composer, Workflow, Grid 
    * `gu:repo` - the GitHub repository where the resource's definition can be found
+   * `gu:application-repo` - the GitHub repository where the application code can be found
  * If a resource needs to be shared across multiple environments, prefer to define it in it's own CFN template as the same resource cannot be defined in multiple templates
  * Prefer continuous delivery of infrastructure via Riff-Raff over manual deployment
    * This provides a better audit trail


### PR DESCRIPTION
## What is being recommended?

<!-- A brief description of what is being recommended here -->
This PR adds to the set of standard AWS tags to include `gu:tool` and `gu:application-repo`. Hopefully the text content is descriptive enough to explain their use.

## What's the context?

<!-- What lead to this recommendation being written, any context or [ADRs](https://docs.aws.amazon.com/prescriptive-guidance/latest/architectural-decision-records/adr-process.html) or related proposals. -->
Related to the tools audit work and this comment: https://github.com/guardian/service-catalogue/pull/1525#discussion_r2091521062

These new tags are intended to make it easier to map between the resources that make up a project.

> **Note**
> 
> The recommendations in this repository are intended to share engineering best practices for all of Product & Engineering (P&E) in the open. 
> 
> Some considerations:
>  - Should this really be an ADR in another repository?
>  - Have you sought review widely enough (Developer Experience, Heads of Engineering)? 
>  - If it is security related, should you consult with Information Security?
