### PR TITLE
Update GitHub recommendations

### DIFF
--- a/github.md
+++ b/github.md
@@ -11,12 +11,6 @@ These requirements are intended to make it easier to manage user accounts and un
 
 ## Creating a new repository
 
-The recommended method for spawning a new repository is using https://repo.new/ (which redirects to https://github.com/new/).
-
-![image](https://github.com/guardian/recommendations/assets/52038/3acc15cf-0465-4133-9a18-0d4cb6eca754)
-
-Bear in mind:
-
 * The repository Owner should be `guardian`
 * The best visibility for most repositories is `Public`, rather than `Internal` or `Private`.
   [Developing in the Open](https://www.theguardian.com/info/developer-blog/2014/nov/28/developing-in-the-open) makes better software!
@@ -60,9 +54,9 @@ Access should be granted to [GitHub teams][gh-teams]. Avoid individual access.
 Should an individual leave the GitHub organisation, they'll automatically lose access to all repositories when access is granted via teams.
 When individual access is granted, they'll retain access to a repository until manually removed.
 
-Generally, new repositories should be open to the department via `Internal` visibility (for read access) and by granting write access to the [`@guardian/guardian-developers-write`][gh-write] team.
+By default, new repositories are open to the department via `Internal` visibility (for read access).
 
-(Existing `Private` repositories may achieve the same effect by additionally granting read access to [`@guardian/guardian-developers-read`][gh-read]. This approach is not recommended since GitHub's introduction of `Internal` visibility.)
+(Existing `Private` repositories may be converted to `Internal` if their contents is not particularly sensitive)
 
 ### Collaborators and CODEOWNERS
 Include at least one GitHub team as a collaborator with admin access. *At an organisational level, this identifies owners for every repository, so that we can better ensure security and maintenance work is under the remit of a team for all our (production) code.*


### PR DESCRIPTION
## What is being recommended?

- Adds `interactive` as a valid status topic
- Remove recommendations that were added to highlight the deprecation of repo-genesis, as this happened two years ago and is less relevant today
- Clarify documentation about repository visibility, and remove an unrecommended approach.

## What's the context?

Since we are now [tracking](https://github.com/guardian/service-catalogue/pull/1592) the number of repos that don't have a production status, I'm updating the recommendations on how to classify repos.

While I'm here, I've updated some other parts of the docs that are confusing or less relevant.

With the upcoming security training, it's now more important that this information is up-to-date.
