### PR TITLE
Add permission recommendations for GHA workflows

### DIFF
--- a/github-actions.md
+++ b/github-actions.md
@@ -98,7 +98,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           # Restrict the installation token to only the permissions needed
           permission-contents: read

--- a/github-actions.md
+++ b/github-actions.md
@@ -45,7 +45,7 @@ By default, GitHub grants `GITHUB_TOKEN` either read-only or read-write permissi
 
 ### Why this matters
 
-A compromised or malicious action running within a job could abuse broad `GITHUB_TOKEN` permissions to, for example, push code, create releases, or read secrets. Scoping permissions tightly limits the blast radius of such an event.
+A compromised or malicious action running within a job could exploit broad `GITHUB_TOKEN` permissions to, for example, push code, create releases, or read secrets. Scoping permissions tightly limits the blast radius of such an event.
 
 ### Example
 

--- a/github-actions.md
+++ b/github-actions.md
@@ -34,3 +34,80 @@ git ls-remote --tags https://github.com/actions/checkout | sort -Vr -k2
 ## Keep actions up to date with Dependabot
 
 Use Dependabot to keep all actions up to date. See [Keeping your actions up to date with Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot).
+
+## Workflow permissions
+
+Workflow permissions control what a workflow or job is allowed to do with the GitHub API and repository resources. They are granted to the automatically created `GITHUB_TOKEN` secret, which is used to authenticate within a workflow run.
+
+Permissions can be set at the workflow level (applying to all jobs) or overridden at the individual job level. Setting them at the job level is preferred as it applies the principle of least privilege; each job receives only the access it needs.
+
+By default, GitHub grants `GITHUB_TOKEN` either read-only or read-write permissions depending on your repository settings. Explicitly declaring permissions in your workflow makes the intended access clear and prevents accidental over-permissioning.
+
+### Why this matters
+
+A compromised or malicious action running within a job could abuse broad `GITHUB_TOKEN` permissions to, for example, push code, create releases, or read secrets. Scoping permissions tightly limits the blast radius of such an event.
+
+### Example
+
+```yaml
+# Workflow-level default: restrict everything to read-only
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # Job-level override: this job needs no additional permissions
+    permissions: {}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+  publish:
+    runs-on: ubuntu-latest
+    # Job-level override: publishing requires write access to packages
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+```
+
+We recommend that you:
+- set a restrictive workflow-level default (for example, `contents: read`) and grant additional permissions per job only where needed
+- prefer `permissions: {}` for jobs that require no GitHub API access
+- avoid `permissions: write-all`
+- review permissions when adding new jobs or actions, especially third-party ones
+
+See the [GitHub documentation on workflow permissions](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token) for the full list of available permission scopes and their effects.
+
+## GitHub app permissions
+
+When a workflow needs to act as a GitHub app (for example, to obtain an installation token with elevated or cross-repository access), the permissions granted to that token should also be restricted to the minimum required.
+
+Actions such as [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token) accept a `permission` input that limits the scopes included in the generated installation token. Explicitly declaring these scopes follows the same principle of least privilege as job-level `GITHUB_TOKEN` permissions and reduces the blast radius if the token is misused or leaked.
+
+### Example
+
+```yaml
+jobs:
+  get-token:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Restrict the installation token to only the permissions needed
+          permission-contents: read
+          permission-pull-requests: write
+```
+
+We recommend that you:
+- always declare explicit permission inputs when generating an installation token rather than relying on the app's full permission set
+- limit scopes to those actually required by the job
+- review app permissions when the workflow changes, in the same way you would review `GITHUB_TOKEN` permissions
+
+See the [GitHub documentation on creating installation access tokens](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app) and the [`actions/create-github-app-token` documentation](https://github.com/actions/create-github-app-token) for full details.

--- a/github-actions.md
+++ b/github-actions.md
@@ -57,8 +57,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # Job-level override: this job needs no additional permissions
-    permissions: {}
+    # No job-level override: this job uses workflow-level permissions
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
## What is being recommended?
Permissions should be set explicitly in GHA workflows so that the scope permitted to a job is clear.

## What's the context?
A query about best practices for using third-party actions.
