### PR TITLE
Add guexperiments.co.uk to domains recommendations

### DIFF
--- a/domain-names.md
+++ b/domain-names.md
@@ -27,9 +27,11 @@ TLS termination should be handled by [Fastly](cdn.md) even if your content is no
 
 **guardianapis.com** should be used for any system whose users are primarily machines rather than people. It will typically serve JSON or binary protocol rather than HTML. It should never appear in an internal or external user’s address bar. It should not use or set cookies.
 
-**gutools.co.uk** should only be used for internal facing tooling. But this is not limited to editorial tools, and can include marketing, engineering or any other tool with an internal audience.
+**gutools.co.uk** should only be used for internal facing tooling. But this is not limited to editorial tools, and can include marketing, engineering or any other tool with an internal audience that is maintained by a Guardian team. Tools should be added to the [tools index](https://tools.gutools.co.uk)
 
 **guim.co.uk** should only be used for public static assets primarily required by our public facing website and apps.
+
+**guexperiments.co.uk** should only be used for internal experiments. Experiments might be hack day or 10% time projects or really anything that isn't properly supported. If an experiment becomes a team-supported tool, it should be migrated to gutools.co.uk. If it becomes a reader-facing app, it should move to theguardian.com or guardianapis.com. Experiments should be added to the [experiments index](https://experiments.guexperiments.co.uk)
 
 ## Non-production stages
 


### PR DESCRIPTION
## What is being recommended?

We've registered a new domain (guexperiments.co.uk) which we plan to use for things that are a bit like tools but without the implied departmental support of a gutools.co.uk project. For example 10% projects, hack day projects or just things that teams build but plan to throw away.

## What's the context?

There are a few projects on gutools.co.uk that aren't properly supported. We've identified that sometimes this happens because there wasn't an obvious place for experimentation.

> **Note**
> 
> The recommendations in this repository are intended to share engineering best practices for all of Product & Engineering (P&E) in the open. 
> 
> Some considerations:
>  - Should this really be an ADR in another repository?
>  - Have you sought review widely enough (Developer Experience, Heads of Engineering)? 
>  - If it is security related, should you consult with Information Security?
