### PR TITLE
Recommend GitHub Rulesets over Branch Protection Rules

### DIFF
--- a/github-rulesets.md
+++ b/github-rulesets.md
@@ -1,23 +1,34 @@
 # GitHub Rulesets
 
-Rulesets can be used to apply branch protection and CI status check rules to a repo, in the case where branch protection needs to be bypassed in certain cases. 
+Rulesets (rather than the legacy method of [Branch protection **rules**](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches))
+should be used to apply branch protection and CI status check rules to a repo.
 
-An example of this is the [GHA Scala Library Release Workflow](https://github.com/guardian/gha-scala-library-release-workflow), which requires branch protection to be turned off in order for it to be able to run. 
+Some of the GitHub Apps we use (eg [GHA Scala Library Release Workflow](https://github.com/guardian/gha-scala-library-release-workflow))
+require the ability to bypass branch protection restrictions, and it is
+only possible to grant this when using GitHub **Rulesets**.
 
-To re-apply branch protection of the default branch via rulesets:
+Recommended Rulesets are listed below:
+
+## 1. Apply branch protection to the default branch
+
+We have a ruleset for this defined at the GitHub-org level which can be automatically applied
+to your repo:
 
 * Edit the Custom Property `production_status` on your repo to select `production` (note, this step requires
-  [GitHub-org-owner privileges](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-organization-settings/managing-custom-properties-for-repositories-in-your-organization#setting-values-for-repositories-in-your-organization)).
-  This will enable an organisation-level ruleset on your repo which applies branch protection to the default branch. (N.B. This ruleset is configured to allow the 'Gu Scala Library Release' app to bypass the branch protection.)
+  [GitHub-org-owner privileges](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-organization-settings/managing-custom-properties-for-repositories-in-your-organization)).
+  This will enable the organisation-level ruleset on your repo which applies branch protection to the default branch.
+  (N.B. This ruleset is configured to allow the 'Gu Scala Library Release' app to bypass the branch protection.)
 
-To require CI checks to pass before merge:
-* Create a second ruleset in your repo with the 'Branch protection' property 'Require status checks to pass' -> 'Require branches to be up to date before merging'.
+## 2. Require CI checks to pass before merge
+
+Unfortunately this ruleset can't be defined at the org-wide level, so you must manually create it
+yourself:
+
+* Create a ruleset in your repo with the 'Branch protection' property:
+  'Require status checks to pass' -> 'Require branches to be up to date before merging'.
 * Type your CI workflow's job name(s) into the 'Status checks that are required' box. 
   * For example, if your repo has a CI workflow with a job called 'CI', then the setting would look like this:
 ![status_checks.png](images/status_checks.png)
   * Or if your workflow has several jobs called 'build', 'trigger-workflow' and 'check-status', it would look like this:
 ![status_checks.png](images/status_checks_jobs.png)
-* Add your app (e.g. 'Gu Scala Library Release') to the ruleset bypass list.
-
-### To enable your repo to access the GitHub App
-* Add your repo to the repository access list of your app (e.g. 'Gu Scala Library Release'). A GitHub admin is required for this).
+* Add relevant GitHub apps (e.g. 'Gu Scala Library Release') to the ruleset bypass list.

--- a/github.md
+++ b/github.md
@@ -36,7 +36,14 @@ Particularly when [continuous deployment] is configured, branch protection reduc
 - Require branches to be up to date before merging
 - Include administrators
 
-If you need to disable branch protection, e.g. in order to use the [Scala release workflow](https://github.com/guardian/gha-scala-library-release-workflow), you should [re-enable protection via rulesets](github-rulesets.md), which allow for protection to be bypassed in certain specific cases.
+GitHub provides two ways to configure branch protection:
+
+* [Branch protection **rules**](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) **(Legacy)**
+* [Branch protection **rulesets**](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) **(Preferred)** - see our [GitHub Ruleset recommendations](github-rulesets.md). This is _essential_ for repos that need to allow GitHub apps to bypass restrictions, eg to use the [Scala release workflow](https://github.com/guardian/gha-scala-library-release-workflow)
+
+If switching a repo to Branch protection **rulesets**, ensure all Branch protection **rules**
+are removed, to avoid confusion and ensure the restriction-bypasses allowed by the Rulesets
+are successfully granted.
 
 ### Access
 Access should be granted to [GitHub teams][gh-teams]. Avoid individual access.


### PR DESCRIPTION
## What is being recommended?

Use GitHub Rulesets over Branch Protection Rules to provide branch protection on repos. Any new repo should use rulesets for preference.

## What's the context?

@davidfurey used a bot to search for inconsistencies in our recommendations repo, which prompted him to ask why:

> ...we only use Rulesets for branch protection on repos using GHA Scala Library Release Workflow rather than using it for all repos?

The truth is that it is [_required_ for repos using GHA Scala Library Release Workflow](https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/configuration.md#branch-protection), but probably also a good idea for other repos too:

* more consistent
* allows repos to take advantage of our org-wide rulesets
* Rulesets are more configurable and have capabilities like GitHub App restrictions bypass that Branch Protection Rules do not have

